### PR TITLE
Reduce tree size before saving them

### DIFF
--- a/pymc_experimental/bart/tree.py
+++ b/pymc_experimental/bart/tree.py
@@ -74,22 +74,28 @@ class Tree:
             self.idx_leaf_nodes.remove(index)
         del self.tree_structure[index]
 
-    def predict_output(self, excluded=None):
+    def trim(self):
+        a_tree = self.copy()
+        del a_tree.num_observations
+        del a_tree.idx_leaf_nodes
+        for k, v in a_tree.tree_structure.items():
+            current_node = a_tree[k]
+            del current_node.depth
+            if isinstance(current_node, LeafNode):
+                del current_node.idx_data_points
+        return a_tree
+
+    def _predict(self):
         output = np.zeros(self.num_observations)
         for node_index in self.idx_leaf_nodes:
             leaf_node = self.get_node(node_index)
-            if excluded is None:
-                output[leaf_node.idx_data_points] = leaf_node.value
-            else:
-                parent_node = leaf_node.get_idx_parent_node()
-                if self.get_node(parent_node).idx_split_variable not in excluded:
-                    output[leaf_node.idx_data_points] = leaf_node.value
+            output[leaf_node.idx_data_points] = leaf_node.value
 
         return output.astype(aesara.config.floatX)
 
-    def predict_out_of_sample(self, X, excluded=None):
+    def predict(self, X, excluded=None):
         """
-        Predict output of tree for an unobserved point x.
+        Predict output of tree for an (un)observed point X.
 
         Parameters
         ----------

--- a/pymc_experimental/tests/test_bart.py
+++ b/pymc_experimental/tests/test_bart.py
@@ -77,9 +77,9 @@ class TestUtils:
 
     def test_predict(self):
         rng = RandomState(12345)
-        pred_all = pmx.bart.utils.predict(self.idata, rng, size=2)
+        pred_all = pmx.bart.utils.predict(self.idata, rng, X=self.X, size=2)
         rng = RandomState(12345)
-        pred_first = pmx.bart.utils.predict(self.idata, rng, X_new=self.X[:10])
+        pred_first = pmx.bart.utils.predict(self.idata, rng, X=self.X[:10])
 
         assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
         assert pred_all.shape == (2, 50)
@@ -112,7 +112,7 @@ class TestUtils:
         ],
     )
     def test_vi(self, kwargs):
-        pmx.bart.utils.plot_variable_importance(self.idata, **kwargs)
+        pmx.bart.utils.plot_variable_importance(self.idata, X=self.X, **kwargs)
 
     def test_pdp_pandas_labels(self):
         pd = pytest.importorskip("pandas")


### PR DESCRIPTION
The total number of trees is `draw` x `chains` x `m`, this can lead to a high memory use. This PR reduces the memory by removing attributes from trees before saving. The removed attributes are used during fitting but not after.