### PR TITLE
Remove k argument

### DIFF
--- a/pymc_experimental/bart/bart.py
+++ b/pymc_experimental/bart/bart.py
@@ -69,7 +69,7 @@ class BART(NoDistribution):
         Control the prior probability over the depth of the trees. Even when it can takes values in
         the interval (0, 1), it is recommended to be in the interval (0, 0.5].
     k : float
-        Scale parameter for the values of the leaf nodes. Defaults to 2. Recomended to be between 1
+        Scale parameter for the values of the leaf nodes. Defaults to 2. Recommended to be between 1
         and 3.
     split_prior : array-like
         Each element of split_prior should be in the [0, 1] interval and the elements should sum to

--- a/pymc_experimental/bart/bart.py
+++ b/pymc_experimental/bart/bart.py
@@ -68,9 +68,6 @@ class BART(NoDistribution):
     alpha : float
         Control the prior probability over the depth of the trees. Even when it can takes values in
         the interval (0, 1), it is recommended to be in the interval (0, 0.5].
-    k : float
-        Scale parameter for the values of the leaf nodes. Defaults to 2. Recommended to be between 1
-        and 3.
     split_prior : array-like
         Each element of split_prior should be in the [0, 1] interval and the elements should sum to
         1. Otherwise they will be normalized.
@@ -84,7 +81,6 @@ class BART(NoDistribution):
         Y,
         m=50,
         alpha=0.25,
-        k=2,
         split_prior=None,
         **kwargs,
     ):
@@ -102,7 +98,6 @@ class BART(NoDistribution):
                 Y=Y,
                 m=m,
                 alpha=alpha,
-                k=k,
                 split_prior=split_prior,
             ),
         )()
@@ -114,7 +109,7 @@ class BART(NoDistribution):
             return cls.get_moment(rv, size, *rv_inputs)
 
         cls.rv_op = bart_op
-        params = [X, Y, m, alpha, k]
+        params = [X, Y, m, alpha]
         return super().__new__(cls, name, *params, **kwargs)
 
     @classmethod

--- a/pymc_experimental/bart/pgbart.py
+++ b/pymc_experimental/bart/pgbart.py
@@ -40,8 +40,6 @@ class PGBART(ArrayStepShared):
         List of value variables for sampler
     num_particles : int
         Number of particles for the conditional SMC sampler. Defaults to 40
-    max_stages : int
-        Maximum number of iterations of the conditional SMC sampler. Defaults to 100.
     batch : int or tuple
         Number of trees fitted per step. Defaults to  "auto", which is the 10% of the `m` trees
         during tuning and after tuning. If a tuple is passed the first element is the batch size
@@ -59,7 +57,6 @@ class PGBART(ArrayStepShared):
         self,
         vars=None,
         num_particles=40,
-        max_stages=100,
         batch="auto",
         model=None,
     ):
@@ -87,10 +84,10 @@ class PGBART(ArrayStepShared):
         # if data is binary
         Y_unique = np.unique(self.Y)
         if Y_unique.size == 2 and np.all(Y_unique == [0, 1]):
-            self.mu_std = 6 / (self.k * self.m**0.5)
+            mu_std = 3 / (self.k * self.m**0.5)
         # maybe we need to check for count data
         else:
-            self.mu_std = (2 * self.Y.std()) / (self.k * self.m**0.5)
+            mu_std = self.Y.std() / (self.k * self.m**0.5)
 
         self.num_observations = self.X.shape[0]
         self.num_variates = self.X.shape[1]
@@ -103,7 +100,7 @@ class PGBART(ArrayStepShared):
         )
         self.mean = fast_mean()
 
-        self.normal = NormalSampler()
+        self.normal = NormalSampler(mu_std)
         self.prior_prob_leaf_node = compute_prior_probability(self.alpha)
         self.ssv = SampleSplittingVariable(self.alpha_vec)
 
@@ -121,7 +118,6 @@ class PGBART(ArrayStepShared):
         self.log_num_particles = np.log(num_particles)
         self.indices = list(range(2, num_particles))
         self.len_indices = len(self.indices)
-        self.max_stages = max_stages
 
         shared = make_shared_replacements(initial_values, vars, model)
         self.likelihood_logp = logp(initial_values, [model.datalogpt], vars, shared)
@@ -138,25 +134,13 @@ class PGBART(ArrayStepShared):
 
         tree_ids = np.random.choice(range(self.m), replace=False, size=self.batch[~self.tune])
         for tree_id in tree_ids:
+            # Compute the sum of trees without the old tree that we are attempting to replace
+            self.sum_trees_noi = self.sum_trees - self.all_particles[tree_id].tree._predict()
             # Generate an initial set of SMC particles
             # at the end of the algorithm we return one of these particles as the new tree
             particles = self.init_particles(tree_id)
-            # Compute the sum of trees without the old tree, that we are attempting to replace
-            self.sum_trees_noi = self.sum_trees - particles[0].tree._predict()
-            # Resample leaf values for particle 1 which is a copy of the old tree
-            particles[1].sample_leafs(
-                self.sum_trees,
-                self.X,
-                self.mean,
-                self.m,
-                self.normal,
-                self.mu_std,
-            )
 
-            # The old tree and the one with new leafs do not grow so we update the weights only once
-            self.update_weight(particles[0], old=True)
-            self.update_weight(particles[1], old=True)
-            for _ in range(self.max_stages):
+            while True:
                 # Sample each particle (try to grow each tree), except for the first two
                 stop_growing = True
                 for p in particles[2:]:
@@ -170,7 +154,6 @@ class PGBART(ArrayStepShared):
                         self.mean,
                         self.m,
                         self.normal,
-                        self.mu_std,
                     )
                     if tree_grew:
                         self.update_weight(p)
@@ -178,8 +161,9 @@ class PGBART(ArrayStepShared):
                         stop_growing = False
                 if stop_growing:
                     break
+
                 # Normalize weights
-                W_t, normalized_weights = self.normalize(particles[2:])
+                w_t, normalized_weights = self.normalize(particles[2:])
 
                 # Resample all but first two particles
                 new_indices = np.random.choice(
@@ -187,9 +171,9 @@ class PGBART(ArrayStepShared):
                 )
                 particles[2:] = particles[new_indices]
 
-                # Set the new weights
+                # Set the new weight
                 for p in particles[2:]:
-                    p.log_weight = W_t
+                    p.log_weight = w_t
 
             for p in particles[2:]:
                 p.log_weight = p.old_likelihood_logp
@@ -216,25 +200,38 @@ class PGBART(ArrayStepShared):
         return self.sum_trees, [stats]
 
     def normalize(self, particles):
-        """Use logsumexp trick to get W_t and softmax to get normalized_weights."""
+        """Use logsumexp trick to get w_t and softmax to get normalized_weights.
+
+        w_t is the un-normalized weight per particle, we will assign it to the
+        next round of particles, so they all start with the same weight.
+        """
         log_w = np.array([p.log_weight for p in particles])
         log_w_max = log_w.max()
         log_w_ = log_w - log_w_max
-        w_ = np.exp(log_w_)
-        w_sum = w_.sum()
-        W_t = log_w_max + np.log(w_sum) - self.log_num_particles
-        normalized_weights = w_ / w_sum
         # stabilize weights to avoid assigning exactly zero probability to a particle
-        normalized_weights += 1e-12
+        w_ = np.exp(log_w_) + 1e-12
+        w_sum = w_.sum()
+        w_t = log_w_max + np.log(w_sum) - self.log_num_particles
+        normalized_weights = w_ / w_sum
+        # normalized_weights += 1e-12
 
-        return W_t, normalized_weights
+        return w_t, normalized_weights
 
     def init_particles(self, tree_id: int) -> np.ndarray:
         """Initialize particles."""
-        p = self.all_particles[tree_id]
-        particles = [p]
-        particles.append(copy(p))
+        p0 = self.all_particles[tree_id]
+        p1 = copy(p0)
+        p1.sample_leafs(
+            self.sum_trees,
+            self.mean,
+            self.m,
+            self.normal,
+        )
+        # The old tree and the one with new leafs do not grow so we update the weights only once
+        self.update_weight(p0, old=True)
+        self.update_weight(p1, old=True)
 
+        particles = [p0, p1]
         for _ in self.indices:
             particles.append(ParticleTree(self.a_tree))
 
@@ -285,7 +282,6 @@ class ParticleTree:
         mean,
         m,
         normal,
-        mu_std,
     ):
         tree_grew = False
         if self.expansion_nodes:
@@ -305,7 +301,6 @@ class ParticleTree:
                     mean,
                     m,
                     normal,
-                    mu_std,
                 )
                 if index_selected_predictor is not None:
                     new_indexes = self.tree.idx_leaf_nodes[-2:]
@@ -315,9 +310,19 @@ class ParticleTree:
 
         return tree_grew
 
-    def sample_leafs(self, sum_trees, X, mean, m, normal, mu_std):
+    def sample_leafs(self, sum_trees, mean, m, normal):
 
-        sample_leaf_values(self.tree, sum_trees, X, mean, m, normal, mu_std)
+        for idx in self.tree.idx_leaf_nodes:
+            if idx > 0:
+                leaf = self.tree[idx]
+                idx_data_points = leaf.idx_data_points
+                node_value = draw_leaf_value(
+                    sum_trees[idx_data_points],
+                    mean,
+                    m,
+                    normal,
+                )
+                leaf.value = node_value
 
 
 class SampleSplittingVariable:
@@ -375,7 +380,6 @@ def grow_tree(
     mean,
     m,
     normal,
-    mu_std,
 ):
     current_node = tree.get_node(index_leaf_node)
     idx_data_points = current_node.idx_data_points
@@ -406,11 +410,9 @@ def grow_tree(
             idx_data_point = new_idx_data_points[idx]
             node_value = draw_leaf_value(
                 sum_trees[idx_data_point],
-                X[idx_data_point, selected_predictor],
                 mean,
                 m,
                 normal,
-                mu_std,
             )
 
             new_node = LeafNode(
@@ -435,25 +437,6 @@ def grow_tree(
         return index_selected_predictor
 
 
-def sample_leaf_values(tree, sum_trees, X, mean, m, normal, mu_std):
-
-    for idx in tree.idx_leaf_nodes:
-        if idx > 0:
-            leaf = tree[idx]
-            idx_data_points = leaf.idx_data_points
-            parent_node = tree[leaf.get_idx_parent_node()]
-            selected_predictor = parent_node.idx_split_variable
-            node_value = draw_leaf_value(
-                sum_trees[idx_data_points],
-                X[idx_data_points, selected_predictor],
-                mean,
-                m,
-                normal,
-                mu_std,
-            )
-            leaf.value = node_value
-
-
 def get_new_idx_data_points(split_value, idx_data_points, selected_predictor, X):
 
     left_idx = X[idx_data_points, selected_predictor] <= split_value
@@ -463,12 +446,12 @@ def get_new_idx_data_points(split_value, idx_data_points, selected_predictor, X)
     return left_node_idx_data_points, right_node_idx_data_points
 
 
-def draw_leaf_value(Y_mu_pred, X_mu, mean, m, normal, mu_std):
+def draw_leaf_value(Y_mu_pred, mean, m, normal):
     """Draw Gaussian distributed leaf values."""
     if Y_mu_pred.size == 0:
         return 0
     else:
-        norm = normal.random() * mu_std
+        norm = normal.random()
         if Y_mu_pred.size == 1:
             mu_mean = Y_mu_pred.item() / m
         else:
@@ -507,9 +490,10 @@ def discrete_uniform_sampler(upper_value):
 class NormalSampler:
     """Cache samples from a standard normal distribution."""
 
-    def __init__(self):
+    def __init__(self, scale):
         self.size = 1000
         self.cache = []
+        self.scale = scale
 
     def random(self):
         if not self.cache:
@@ -517,7 +501,7 @@ class NormalSampler:
         return self.cache.pop()
 
     def update(self):
-        self.cache = np.random.normal(loc=0.0, scale=1, size=self.size).tolist()
+        self.cache = np.random.normal(loc=0.0, scale=self.scale, size=self.size).tolist()
 
 
 def logp(point, out_vars, vars, shared):

--- a/pymc_experimental/bart/tree.py
+++ b/pymc_experimental/bart/tree.py
@@ -78,7 +78,7 @@ class Tree:
         a_tree = self.copy()
         del a_tree.num_observations
         del a_tree.idx_leaf_nodes
-        for k, _ in a_tree.tree_structure.items():
+        for k in a_tree.tree_structure.keys():
             current_node = a_tree[k]
             del current_node.depth
             if isinstance(current_node, LeafNode):

--- a/pymc_experimental/bart/tree.py
+++ b/pymc_experimental/bart/tree.py
@@ -78,7 +78,7 @@ class Tree:
         a_tree = self.copy()
         del a_tree.num_observations
         del a_tree.idx_leaf_nodes
-        for k, v in a_tree.tree_structure.items():
+        for k, _ in a_tree.tree_structure.items():
             current_node = a_tree[k]
             del current_node.depth
             if isinstance(current_node, LeafNode):


### PR DESCRIPTION
This removes the need to set the value of `k`, that affects the  value of mu_std. We now instead sample k from a uniform distribution when particles are created during tuning.

Additionally in this PR we:

* Refactor `init_particles`,
* Remove `max_stages` because is not actually needed
* Other small changes to make code more clear to read