### PR TITLE
BART: add shape argument

### DIFF
--- a/pymc_experimental/bart/bart.py
+++ b/pymc_experimental/bart/bart.py
@@ -40,15 +40,18 @@ class BARTRV(RandomVariable):
         )
 
     def _infer_shape(cls, size, dist_params, param_shapes=None):
-        if cls.shape > 1:
-            dist_shape = (cls.X.shape[0], cls.shape)
+        if cls.shape is not None:
+            dist_shape = (cls.shape, cls.X.shape[0])
         else:
             dist_shape = (cls.X.shape[0],)
         return dist_shape
 
     @classmethod
     def rng_fn(cls, rng=np.random.default_rng(), *args, **kwargs):
-        return np.full((cls.Y.shape[0], cls.shape), cls.Y.mean()).squeeze()
+        if cls.shape is not None:
+            return np.full((cls.shape, cls.Y.shape[0]), cls.Y.mean())
+        else:
+            return np.full(cls.Y.shape[0], cls.Y.mean())
 
 
 bart = BARTRV()
@@ -76,7 +79,7 @@ class BART(NoDistribution):
         1. Otherwise they will be normalized.
         Defaults to None, i.e. all covariates have the same prior probability to be selected.
     shape : int
-        If 1 (default) the BART distribution will have shape Y.shape[0]. If larger it will have  shape (Y.shape[0], shape).
+        If None (default) the BART distribution will have shape Y.shape[0]. If and integer larger than 1 it will have shape (Y.shape[0], shape).
     """
 
     def __new__(
@@ -87,7 +90,7 @@ class BART(NoDistribution):
         m=50,
         alpha=0.25,
         split_prior=None,
-        shape=1,
+        shape=None,
         **kwargs,
     ):
 

--- a/pymc_experimental/bart/pgbart.py
+++ b/pymc_experimental/bart/pgbart.py
@@ -538,20 +538,22 @@ class NormalSampler:
 
     def __init__(self, scale, shape):
         self.size = 1000
-        self.cache = []
         self.scale = scale
         self.shape = shape
+        self.update()
+
 
     def random(self):
-        if not self.cache:
+        if self.idx == self.size:
             self.update()
-        return np.array(self.cache.pop()).T
+        pop = self.cache[:, self.idx]
+        self.idx += 1
+        return pop
 
     def update(self):
+        self.idx = 0
         self.cache = (
-            np.random.normal(loc=0.0, scale=self.scale, size=(self.size, self.shape))
-            .squeeze()
-            .tolist()
+            np.random.normal(loc=0.0, scale=self.scale, size=(self.shape, self.size))
         )
 
 
@@ -560,21 +562,22 @@ class UniformSampler:
 
     def __init__(self, lower_bound, upper_bound, shape):
         self.size = 1000
-        self.cache = []
-        self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+        self.lower_bound = lower_bound
         self.shape = shape
+        self.update()
 
     def random(self):
-        if not self.cache:
+        if self.idx == self.size:
             self.update()
-        return np.array(self.cache.pop()).T
+        pop = self.cache[:, self.idx]
+        self.idx += 1
+        return pop
 
     def update(self):
+        self.idx = 0
         self.cache = (
-            np.random.uniform(self.lower_bound, self.upper_bound, size=(self.size, self.shape))
-            .squeeze()
-            .tolist()
+            np.random.uniform(self.lower_bound, self.upper_bound, size=(self.shape, self.size))
         )
 
 

--- a/pymc_experimental/bart/pgbart.py
+++ b/pymc_experimental/bart/pgbart.py
@@ -75,13 +75,13 @@ class PGBART(ArrayStepShared):
         self.missing_data = np.any(np.isnan(self.X))
         self.m = self.bart.m
         self.alpha = self.bart.alpha
-        self.shape = self.bart.shape
-        if self.shape is None:
+        shape = initial_values[value_bart.name].shape
+        if len(shape) == 1:
             self.shape = 1
-        self.alpha_vec = self.bart.split_prior
-        if self.alpha_vec is None:
-            self.alpha_vec = np.ones(self.X.shape[1])
+        else:
+            self.shape = shape[0]
 
+        self.alpha_vec = self.bart.split_prior
         self.init_mean = self.Y.mean()
         # if data is binary
         Y_unique = np.unique(self.Y)
@@ -127,7 +127,7 @@ class PGBART(ArrayStepShared):
         self.len_indices = len(self.indices)
 
         shared = make_shared_replacements(initial_values, vars, model)
-        self.likelihood_logp = logp(initial_values, [model.datalogpt], vars, shared)
+        self.likelihood_logp = logp(initial_values, [model.datalogp], vars, shared)
         self.all_particles = []
         for _ in range(self.m):
             self.a_tree.leaf_node_value = self.init_mean / self.m
@@ -542,7 +542,6 @@ class NormalSampler:
         self.shape = shape
         self.update()
 
-
     def random(self):
         if self.idx == self.size:
             self.update()
@@ -552,9 +551,7 @@ class NormalSampler:
 
     def update(self):
         self.idx = 0
-        self.cache = (
-            np.random.normal(loc=0.0, scale=self.scale, size=(self.shape, self.size))
-        )
+        self.cache = np.random.normal(loc=0.0, scale=self.scale, size=(self.shape, self.size))
 
 
 class UniformSampler:
@@ -576,8 +573,8 @@ class UniformSampler:
 
     def update(self):
         self.idx = 0
-        self.cache = (
-            np.random.uniform(self.lower_bound, self.upper_bound, size=(self.shape, self.size))
+        self.cache = np.random.uniform(
+            self.lower_bound, self.upper_bound, size=(self.shape, self.size)
         )
 
 

--- a/pymc_experimental/bart/tree.py
+++ b/pymc_experimental/bart/tree.py
@@ -46,10 +46,10 @@ class Tree:
     num_observations : int, optional
     """
 
-    def __init__(self, num_observations=0):
+    def __init__(self, num_observations=0, shape=1):
         self.tree_structure = {}
         self.idx_leaf_nodes = []
-        self.num_observations = num_observations
+        self.output = np.zeros((num_observations, shape)).astype(aesara.config.floatX).squeeze()
 
     def __getitem__(self, index):
         return self.get_node(index)
@@ -74,7 +74,7 @@ class Tree:
 
     def trim(self):
         a_tree = self.copy()
-        del a_tree.num_observations
+        del a_tree.output
         del a_tree.idx_leaf_nodes
         for k in a_tree.tree_structure.keys():
             current_node = a_tree[k]
@@ -84,12 +84,12 @@ class Tree:
         return a_tree
 
     def _predict(self):
-        output = np.zeros(self.num_observations)
+        output = self.output
         for node_index in self.idx_leaf_nodes:
             leaf_node = self.get_node(node_index)
             output[leaf_node.idx_data_points] = leaf_node.value
 
-        return output.astype(aesara.config.floatX)
+        return output
 
     def predict(self, X, excluded=None):
         """
@@ -137,7 +137,7 @@ class Tree:
         return current_node
 
     @staticmethod
-    def init_tree(leaf_node_value, idx_data_points):
+    def init_tree(leaf_node_value, idx_data_points, shape):
         """
         Initialize tree.
 
@@ -150,7 +150,7 @@ class Tree:
         -------
         tree
         """
-        new_tree = Tree(len(idx_data_points))
+        new_tree = Tree(len(idx_data_points), shape)
         new_tree[0] = LeafNode(index=0, value=leaf_node_value, idx_data_points=idx_data_points)
         return new_tree
 

--- a/pymc_experimental/bart/tree.py
+++ b/pymc_experimental/bart/tree.py
@@ -49,7 +49,10 @@ class Tree:
     def __init__(self, num_observations=0, shape=1):
         self.tree_structure = {}
         self.idx_leaf_nodes = []
-        self.output = np.zeros((num_observations, shape)).astype(aesara.config.floatX).squeeze()
+        self.shape = shape
+        self.output = (
+            np.zeros((num_observations, self.shape)).astype(aesara.config.floatX).squeeze()
+        )
 
     def __getitem__(self, index):
         return self.get_node(index)
@@ -88,8 +91,7 @@ class Tree:
         for node_index in self.idx_leaf_nodes:
             leaf_node = self.get_node(node_index)
             output[leaf_node.idx_data_points] = leaf_node.value
-
-        return output
+        return output.T
 
     def predict(self, X, excluded=None):
         """
@@ -110,7 +112,7 @@ class Tree:
         if excluded is not None:
             parent_node = leaf_node.get_idx_parent_node()
             if self.get_node(parent_node).idx_split_variable in excluded:
-                leaf_value = 0.0
+                leaf_value = np.zeros(self.shape)
         return leaf_value
 
     def _traverse_tree(self, x, node_index=0):

--- a/pymc_experimental/bart/utils.py
+++ b/pymc_experimental/bart/utils.py
@@ -39,12 +39,21 @@ def predict(idata, rng, X, size=None, excluded=None):
         flatten_size *= s
 
     idx = rng.randint(len(stacked_trees.trees), size=flatten_size)
+    shape = stacked_trees.isel(trees=0).values[0].predict(X[0]).size
 
-    pred = np.zeros((flatten_size, X.shape[0]))
+    if shape > 1:
+        pred = np.zeros((flatten_size, X.shape[0], shape))
+    else:
+        pred = np.zeros((flatten_size, X.shape[0]))
+
     for ind, p in enumerate(pred):
         for tree in stacked_trees.isel(trees=idx[ind]).values:
             p += np.array([tree.predict(x, excluded) for x in X])
-    return pred.reshape((*size, -1))
+    if shape > 1:
+        pred.reshape((*size, -1, shape))
+    else:
+        pred.reshape((*size, -1))
+    return pred
 
 
 def plot_dependence(
@@ -215,11 +224,14 @@ def plot_dependence(
         y_mins.append(np.min(y_pred))
         new_Y.append(np.array(y_pred).T)
 
+    shape = 1
+    if new_Y[0].ndim == 3:
+        shape = new_Y[0].shape[0]
     if ax is None:
         if grid == "long":
-            fig, axes = plt.subplots(len(var_idx), sharey=sharey, figsize=figsize)
+            fig, axes = plt.subplots(len(var_idx) * shape, sharey=sharey, figsize=figsize)
         elif grid == "wide":
-            fig, axes = plt.subplots(1, len(var_idx), sharey=sharey, figsize=figsize)
+            fig, axes = plt.subplots(1, len(var_idx) * shape, sharey=sharey, figsize=figsize)
         elif isinstance(grid, tuple):
             fig, axes = plt.subplots(grid[0], grid[1], sharey=sharey, figsize=figsize)
         axes = np.ravel(axes)
@@ -227,70 +239,82 @@ def plot_dependence(
         axes = [ax]
         fig = ax.get_figure()
 
-    for i, ax in enumerate(axes):
-        if i >= len(var_idx):
+    x_idx = 0
+    y_idx = 0
+    for ax in axes:
+        if x_idx >= len(var_idx):
             ax.set_axis_off()
             fig.delaxes(ax)
+
+        if shape == 1:
+            nyi = new_Y[x_idx]
+            nxi = new_X_target[x_idx]
+            var = var_idx[x_idx]
         else:
-            var = var_idx[i]
-            if var in var_discrete:
-                if kind == "pdp":
-                    y_means = new_Y[i].mean(0)
-                    hdi = az.hdi(new_Y[i])
-                    ax.errorbar(
-                        new_X_target[i],
-                        y_means,
-                        (y_means - hdi[:, 0], hdi[:, 1] - y_means),
-                        fmt=".",
-                        color=color,
-                    )
-                else:
-                    ax.plot(new_X_target[i], new_Y[i], ".", color=color, alpha=alpha)
-                    ax.plot(new_X_target[i], new_Y[i].mean(1), "o", color=color_mean)
-                ax.set_xticks(new_X_target[i])
-            elif smooth:
-                if smooth_kwargs is None:
-                    smooth_kwargs = {}
-                smooth_kwargs.setdefault("window_length", 55)
-                smooth_kwargs.setdefault("polyorder", 2)
-                x_data = np.linspace(np.nanmin(new_X_target[i]), np.nanmax(new_X_target[i]), 200)
-                x_data[0] = (x_data[0] + x_data[1]) / 2
-                if kind == "pdp":
-                    interp = griddata(new_X_target[i], new_Y[i].mean(0), x_data)
-                else:
-                    interp = griddata(new_X_target[i], new_Y[i], x_data)
+            nyi = new_Y[x_idx][y_idx]
+            nxi = new_X_target[x_idx]
+            var = var_idx[x_idx]
 
-                y_data = savgol_filter(interp, axis=0, **smooth_kwargs)
+        ax.set_xlabel(X_labels[x_idx])
+        x_idx += 1
+        if x_idx == len(var_idx):
+            x_idx = 0
+            y_idx += 1
 
-                if kind == "pdp":
-                    az.plot_hdi(
-                        new_X_target[i], new_Y[i], color=color, fill_kwargs={"alpha": alpha}, ax=ax
-                    )
-                    ax.plot(x_data, y_data, color=color_mean)
-                else:
-                    ax.plot(x_data, y_data.mean(1), color=color_mean)
-                    ax.plot(x_data, y_data, color=color, alpha=alpha)
-
+        if var in var_discrete:
+            if kind == "pdp":
+                y_means = nyi.mean(0)
+                hdi = az.hdi(nyi)
+                ax.errorbar(
+                    nxi,
+                    y_means,
+                    (y_means - hdi[:, 0], hdi[:, 1] - y_means),
+                    fmt=".",
+                    color=color,
+                )
             else:
-                idx = np.argsort(new_X_target[i])
-                if kind == "pdp":
-                    az.plot_hdi(
-                        new_X_target[i],
-                        new_Y[i],
-                        smooth=smooth,
-                        fill_kwargs={"alpha": alpha},
-                        ax=ax,
-                    )
-                    ax.plot(new_X_target[i][idx], new_Y[i][idx].mean(0), color=color)
-                else:
-                    ax.plot(new_X_target[i][idx], new_Y[i][idx], color=color, alpha=alpha)
-                    ax.plot(new_X_target[i][idx], new_Y[i][idx].mean(1), color=color_mean)
+                ax.plot(nxi, nyi, ".", color=color, alpha=alpha)
+                ax.plot(nxi, nyi.mean(1), "o", color=color_mean)
+            ax.set_xticks(nxi)
+        elif smooth:
+            if smooth_kwargs is None:
+                smooth_kwargs = {}
+            smooth_kwargs.setdefault("window_length", 55)
+            smooth_kwargs.setdefault("polyorder", 2)
+            x_data = np.linspace(np.nanmin(nxi), np.nanmax(nxi), 200)
+            x_data[0] = (x_data[0] + x_data[1]) / 2
+            if kind == "pdp":
+                interp = griddata(nxi, nyi.mean(0), x_data)
+            else:
+                interp = griddata(nxi, nyi, x_data)
 
-            if rug:
-                lb = np.min(y_mins)
-                ax.plot(X[:, var], np.full_like(X[:, var], lb), "k|")
+            y_data = savgol_filter(interp, axis=0, **smooth_kwargs)
 
-            ax.set_xlabel(X_labels[i])
+            if kind == "pdp":
+                az.plot_hdi(nxi, nyi, color=color, fill_kwargs={"alpha": alpha}, ax=ax)
+                ax.plot(x_data, y_data, color=color_mean)
+            else:
+                ax.plot(x_data, y_data.mean(1), color=color_mean)
+                ax.plot(x_data, y_data, color=color, alpha=alpha)
+
+        else:
+            idx = np.argsort(nxi)
+            if kind == "pdp":
+                az.plot_hdi(
+                    nxi,
+                    nyi,
+                    smooth=smooth,
+                    fill_kwargs={"alpha": alpha},
+                    ax=ax,
+                )
+                ax.plot(nxi[idx], nyi[idx].mean(0), color=color)
+            else:
+                ax.plot(nxi[idx], nyi[idx], color=color, alpha=alpha)
+                ax.plot(nxi[idx], nyi[idx].mean(1), color=color_mean)
+
+        if rug:
+            lb = np.min(y_mins)
+            ax.plot(X[:, var], np.full_like(X[:, var], lb), "k|")
 
     fig.text(-0.05, 0.5, Y_label, va="center", rotation="vertical", fontsize=15)
     return axes

--- a/pymc_experimental/tests/test_bart.py
+++ b/pymc_experimental/tests/test_bart.py
@@ -81,9 +81,9 @@ class TestUtils:
         rng = RandomState(12345)
         pred_first = pmx.bart.utils.predict(self.idata, rng, X=self.X[:10])
 
-        assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
+        assert_almost_equal(pred_first[0], pred_all[0, :10], decimal=4)
         assert pred_all.shape == (2, 50)
-        assert pred_first.shape == (10,)
+        assert pred_first.shape == (1, 10)
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/pymc_experimental/tests/test_bart.py
+++ b/pymc_experimental/tests/test_bart.py
@@ -82,8 +82,8 @@ class TestUtils:
         pred_first = pmx.bart.utils.predict(self.idata, rng, X=self.X[:10])
 
         assert_almost_equal(pred_first[0], pred_all[0, :10], decimal=4)
-        assert pred_all.shape == (2, 50)
-        assert pred_first.shape == (1, 10)
+        assert pred_all.shape == (2, 50, 1)
+        assert pred_first.shape == (1, 10, 1)
 
     @pytest.mark.parametrize(
         "kwargs",


### PR DESCRIPTION
This allows fully non-parametrical models of the form

```python
with pm.Model() as model:
    w = pmx.BART("w", X, Y, shape=2)
    μ = pm.Deterministic("μ", w[0])
    σ = pm.Deterministic("σ", np.abs(w[1]))
    y = pm.Normal("y", μ, σ, observed=Y)
```

or models where the Y is not 1D.