### PR TITLE
Initialize a prior from a fitted posterior

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -29,3 +29,6 @@ methods in the current release of PyMC experimental.
 .. automodule:: pymc_experimental.utils.spline
    :members: bspline_interpolation
 
+.. automodule:: pymc_experimental.utils.prior
+   :members: prior_from_idata
+

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -7,11 +7,16 @@ import pytest
 @pytest.mark.parametrize(
     "case",
     [
-        (("a", dict(name="b")), dict(name="b", transform=None)),
-        (("a", None), dict(name="a", transform=None)),
-        (("a", transforms.log), dict(name="a", transform=transforms.log)),
-        (("a", dict(transform=transforms.log)), dict(name="a", transform=transforms.log)),
-        (("a", dict(name="b")), dict(name="b", transform=None)),
+        (("a", dict(name="b")), dict(name="b", transform=None, dims=None)),
+        (("a", None), dict(name="a", transform=None, dims=None)),
+        (("a", transforms.log), dict(name="a", transform=transforms.log, dims=None)),
+        (
+            ("a", dict(transform=transforms.log)),
+            dict(name="a", transform=transforms.log, dims=None),
+        ),
+        (("a", dict(name="b")), dict(name="b", transform=None, dims=None)),
+        (("a", dict(name="b", dims="test")), dict(name="b", transform=None, dims="test")),
+        (("a", ("test",)), dict(name="a", transform=None, dims=("test",))),
     ],
 )
 def test_parsing_arguments(case):

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -108,8 +108,8 @@ def test_transform_idata(transformed_data, idata, param_cfg):
         expected_shape += int(np.prod(v.shape[2:]))
     assert flat_info["data"].shape[1] == expected_shape
     assert len(flat_info["info"]) == len(param_cfg)
-    assert "sinfo" in param_cfg["info"][0]
-    assert "vinfo" in param_cfg["info"][0]
+    assert "sinfo" in flat_info["info"][0]
+    assert "vinfo" in flat_info["info"][0]
 
 
 @pytest.fixture
@@ -131,7 +131,7 @@ def test_mvn_prior_from_flat_info(flat_info, coords, param_cfg):
     assert set(model.named_vars) == {"trace_prior_", *names}
 
 
-def test_prior_from_idata(idata, user_param_cfg, coords):
+def test_prior_from_idata(idata, user_param_cfg, coords, param_cfg):
     with pm.Model(coords=coords) as model:
         priors = pmx.utils.prior.prior_from_idata(
             idata, var_names=user_param_cfg[0], **user_param_cfg[1]

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -22,7 +22,7 @@ import numpy as np
 )
 def test_parsing_arguments(case):
     inp, out = case
-    test = pmx.utils.prior.arg_to_param_cfg(*inp)
+    test = pmx.utils.prior._arg_to_param_cfg(*inp)
     assert test == out
 
 
@@ -34,9 +34,9 @@ def coords():
 @pytest.fixture
 def param_cfg():
     return dict(
-        a=pmx.utils.prior.arg_to_param_cfg("a"),
-        b=pmx.utils.prior.arg_to_param_cfg("b", dict(transform=transforms.log, dims=("test",))),
-        c=pmx.utils.prior.arg_to_param_cfg(
+        a=pmx.utils.prior._arg_to_param_cfg("a"),
+        b=pmx.utils.prior._arg_to_param_cfg("b", dict(transform=transforms.log, dims=("test",))),
+        c=pmx.utils.prior._arg_to_param_cfg(
             "c", dict(transform=transforms.simplex, dims=("simplex",))
         ),
     )
@@ -64,3 +64,22 @@ def test_idata_for_tests(idata, param_cfg):
     assert set(idata.posterior.keys()) == set(param_cfg)
     assert len(idata.posterior.coords["chain"]) == 4
     assert len(idata.posterior.coords["draw"]) == 100
+
+
+def test_args_compose():
+    cfg = pmx.utils.prior._parse_args(
+        var_names=["a"],
+        b=("test",),
+        c=transforms.log,
+        d="e",
+        f=dict(dims="test"),
+        g=dict(name="h", dims="test", transform=transforms.log),
+    )
+    assert cfg == dict(
+        a=dict(name="a", dims=None, transform=None),
+        b=dict(name="b", dims=("test",), transform=None),
+        c=dict(name="c", dims=None, transform=transforms.log),
+        d=dict(name="e", dims=None, transform=None),
+        f=dict(name="f", dims="test", transform=None),
+        g=dict(name="h", dims="test", transform=transforms.log),
+    )

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -101,3 +101,14 @@ def test_transform_idata(transformed_data, idata, param_cfg):
         expected_shape += int(np.prod(v.shape[2:]))
     assert flat_info["data"].shape[1] == expected_shape
     assert len(flat_info["info"]) == len(param_cfg)
+
+
+@pytest.fixture
+def flat_info(idata, param_cfg):
+    return pmx.utils.prior._flatten(idata, **param_cfg)
+
+
+def test_mean_chol(flat_info):
+    mean, chol = pmx.utils.prior._mean_chol(flat_info["data"])
+    assert mean.shape == (flat_info["data"].shape[1],)
+    assert chol.shape == (flat_info["data"].shape[1],) * 2

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -28,17 +28,17 @@ def test_parsing_arguments(case):
 
 @pytest.fixture
 def coords():
-    return dict(test=range(3))
+    return dict(test=range(3), simplex=range(4))
 
 
 @pytest.fixture
 def param_cfg():
     return dict(
         a=pmx.utils.prior.arg_to_param_cfg("a"),
-        b=pmx.utils.prior.arg_to_param_cfg(
-            "b", dict(transform=transforms.sum_to_1, dims=("test",))
+        b=pmx.utils.prior.arg_to_param_cfg("b", dict(transform=transforms.log, dims=("test",))),
+        c=pmx.utils.prior.arg_to_param_cfg(
+            "c", dict(transform=transforms.simplex, dims=("simplex",))
         ),
-        c=pmx.utils.prior.arg_to_param_cfg("c", dict(transform=transforms.log, dims=("test",))),
     )
 
 
@@ -55,6 +55,7 @@ def idata(param_cfg, coords):
             var = cfg["transform"].backward(orig).eval()
         else:
             var = orig
+        assert not np.isnan(var).any()
         vars[k] = var
     return az.convert_to_inference_data(vars, coords=coords)
 

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -100,3 +100,4 @@ def test_transform_idata(transformed_data, idata, param_cfg):
     for v in transformed_data.values():
         expected_shape += int(np.prod(v.shape[2:]))
     assert flat_info["data"].shape[1] == expected_shape
+    assert len(flat_info["info"]) == len(param_cfg)

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -34,7 +34,7 @@ def coords():
 
 @pytest.fixture
 def user_param_cfg():
-    return (), dict(
+    return ("t", ), dict(
         a="d",
         b=dict(transform=transforms.log, dims=("test",)),
         c=dict(transform=transforms.simplex, dims=("simplex",)),

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -35,7 +35,10 @@ def coords():
 def param_cfg():
     return dict(
         a=pmx.utils.prior.arg_to_param_cfg("a"),
-        b=pmx.utils.prior.arg_to_param_cfg("b", dict(transform=transforms.log, dims=("test",))),
+        b=pmx.utils.prior.arg_to_param_cfg(
+            "b", dict(transform=transforms.sum_to_1, dims=("test",))
+        ),
+        c=pmx.utils.prior.arg_to_param_cfg("c", dict(transform=transforms.log, dims=("test",))),
     )
 
 

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -1,0 +1,20 @@
+import pymc_experimental as pmx
+import pymc as pm
+from pymc.distributions import transforms
+import pytest
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        (("a", dict(name="b")), dict(name="b", transform=None)),
+        (("a", None), dict(name="a", transform=None)),
+        (("a", transforms.log), dict(name="a", transform=transforms.log)),
+        (("a", dict(transform=transforms.log)), dict(name="a", transform=transforms.log)),
+        (("a", dict(name="b")), dict(name="b", transform=None)),
+    ],
+)
+def test_parsing_arguments(case):
+    inp, out = case
+    test = pmx.utils.prior.arg_to_param_cfg(*inp)
+    assert test == out

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -1,7 +1,8 @@
 import pymc_experimental as pmx
-import pymc as pm
 from pymc.distributions import transforms
 import pytest
+import arviz as az
+import numpy as np
 
 
 @pytest.mark.parametrize(
@@ -23,3 +24,16 @@ def test_parsing_arguments(case):
     inp, out = case
     test = pmx.utils.prior.arg_to_param_cfg(*inp)
     assert test == out
+
+
+@pytest.fixture
+def idata():
+    a = np.random.randn(4, 1000, 3)
+    b = np.exp(np.random.randn(4, 1000, 5))
+    return az.convert_to_inference_data(dict(a=a, b=b))
+
+
+def test_idata_for_tests(idata):
+    assert set(idata.posterior.keys()) == {"a", "b"}
+    assert len(idata.posterior.coords["chain"]) == 4
+    assert len(idata.posterior.coords["draw"]) == 1000

--- a/pymc_experimental/tests/test_prior_from_trace.py
+++ b/pymc_experimental/tests/test_prior_from_trace.py
@@ -34,7 +34,7 @@ def coords():
 
 @pytest.fixture
 def user_param_cfg():
-    return ("t", ), dict(
+    return ("t",), dict(
         a="d",
         b=dict(transform=transforms.log, dims=("test",)),
         c=dict(transform=transforms.simplex, dims=("simplex",)),

--- a/pymc_experimental/utils/__init__.py
+++ b/pymc_experimental/utils/__init__.py
@@ -1,1 +1,2 @@
 from pymc_experimental.utils import spline
+from pymc_experimental.utils import prior

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -85,3 +85,10 @@ def _flatten(idata: arviz.InferenceData, **kwargs: ParamCfg) -> FlatInfo:
         info.append(dict(shape=shape, slice=slice(begin, end)))
         begin = end
     return dict(data=np.concatenate(vars, axis=-1), info=info)
+
+
+def _mean_chol(flat_array: np.ndarray):
+    mean = flat_array.mean(0)
+    cov = np.cov(flat_array, rowvar=False)
+    chol = np.linalg.cholesky(cov)
+    return mean, chol

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -115,3 +115,9 @@ def _mvn_prior_from_flat_info(name, flat_info: FlatInfo):
         var = pm.Deterministic(vinfo["name"], var, dims=vinfo["dims"])
         result[vinfo["name"]] = var
     return result
+
+
+def prior_from_idata(idata, name="trace_prior_", *, var_names: Sequence[str] = (), **kwargs):
+    param_cfg = _parse_args(var_names=var_names, **kwargs)
+    flat_info = _flatten(idata, **param_cfg)
+    return _mvn_prior_from_flat_info(name, flat_info)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -9,7 +9,7 @@ class ParamCfg(TypedDict):
 
 
 def arg_to_param_cfg(
-    key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]]
+    key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]] = None
 ):
     if value is None:
         cfg = ParamCfg(name=key, transform=None, dims=None)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Optional, Union, Tuple
+from typing import TypedDict, Optional, Union, Tuple, Sequence, Dict
 import aeppl.transforms
 
 
@@ -8,7 +8,7 @@ class ParamCfg(TypedDict):
     dims: Optional[Union[str, Tuple[str]]]
 
 
-def arg_to_param_cfg(
+def _arg_to_param_cfg(
     key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]] = None
 ):
     if value is None:
@@ -25,3 +25,14 @@ def arg_to_param_cfg(
         cfg.setdefault("transform", None)
         cfg.setdefault("dims", None)
     return cfg
+
+
+def _parse_args(
+    var_names: Sequence[str], **kwargs: Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]
+) -> Dict[str, ParamCfg]:
+    results = dict()
+    for var in var_names:
+        results[var] = _arg_to_param_cfg(var)
+    for key, val in kwargs.items():
+        results[key] = _arg_to_param_cfg(key, val)
+    return results

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -121,7 +121,16 @@ def prior_from_idata(
     **kwargs: Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]
 ) -> Dict[str, at.TensorVariable]:
     """
-    Create a prior from posterior.
+    Create a prior from posterior using MvNormal approximation.
+
+    The approximation uses MvNormal distribution.
+    Keep in mind that this function will only work well for unimodal
+    posteriors and will fail when complicated interactions happen.
+
+    Moreover, if a retrieved variable is constrained, you
+    should specify the transform for the variable, e.g.
+    ``pymc.distributions.transforms.log`` for standard
+    deviation posterior.
 
     Parameters
     ----------

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -73,4 +73,4 @@ def _flatten(idata: arviz.InferenceData, **kwargs: ParamCfg) -> FlatInfo:
         vars.append(data)
         info.append(dict(shape=shape, slice=slice(begin, end)))
         begin = end
-    return dict(data=np.concatenate(vars, axis=-1), infp=info)
+    return dict(data=np.concatenate(vars, axis=-1), info=info)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -2,6 +2,7 @@ from typing import TypedDict, Optional, Union, Tuple, Sequence, Dict, List
 import aeppl.transforms
 import arviz
 import pymc as pm
+import aesara.tensor as at
 import numpy as np
 
 
@@ -117,7 +118,13 @@ def _mvn_prior_from_flat_info(name, flat_info: FlatInfo):
     return result
 
 
-def prior_from_idata(idata, name="trace_prior_", *, var_names: Sequence[str] = (), **kwargs):
+def prior_from_idata(
+    idata,
+    name="trace_prior_",
+    *,
+    var_names: Sequence[str],
+    **kwargs: Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]
+) -> Dict[str, at.TensorVariable]:
     param_cfg = _parse_args(var_names=var_names, **kwargs)
     flat_info = _flatten(idata, **param_cfg)
     return _mvn_prior_from_flat_info(name, flat_info)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -1,21 +1,27 @@
-from typing import TypedDict, Optional, Union
+from typing import TypedDict, Optional, Union, Tuple
 import aeppl.transforms
 
 
 class ParamCfg(TypedDict):
     name: str
     transform: Optional[aeppl.transforms.RVTransform]
+    dims: Optional[Union[str, Tuple[str]]]
 
 
-def arg_to_param_cfg(key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str]]):
+def arg_to_param_cfg(
+    key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str, Tuple]]
+):
     if value is None:
-        cfg = ParamCfg(name=key, transform=None)
+        cfg = ParamCfg(name=key, transform=None, dims=None)
+    elif isinstance(value, Tuple):
+        cfg = ParamCfg(name=key, transform=None, dims=value)
     elif isinstance(value, str):
-        cfg = ParamCfg(name=value, transform=None)
+        cfg = ParamCfg(name=value, transform=None, dims=None)
     elif isinstance(value, aeppl.transforms.RVTransform):
-        cfg = ParamCfg(name=key, transform=value)
+        cfg = ParamCfg(name=key, transform=value, dims=None)
     else:
         cfg = value.copy()
         cfg.setdefault("name", key)
         cfg.setdefault("transform", None)
+        cfg.setdefault("dims", None)
     return cfg

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -1,0 +1,21 @@
+from typing import TypedDict, Optional, Union
+import aeppl.transforms
+
+
+class ParamCfg(TypedDict):
+    name: str
+    transform: Optional[aeppl.transforms.RVTransform]
+
+
+def arg_to_param_cfg(key, value: Optional[Union[ParamCfg, aeppl.transforms.RVTransform, str]]):
+    if value is None:
+        cfg = ParamCfg(name=key, transform=None)
+    elif isinstance(value, str):
+        cfg = ParamCfg(name=value, transform=None)
+    elif isinstance(value, aeppl.transforms.RVTransform):
+        cfg = ParamCfg(name=key, transform=value)
+    else:
+        cfg = value.copy()
+        cfg.setdefault("name", key)
+        cfg.setdefault("transform", None)
+    return cfg

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -128,7 +128,7 @@ def prior_from_idata(
     posteriors and will fail when complicated interactions happen.
 
     Moreover, if a retrieved variable is constrained, you
-    should specify the transform for the variable, e.g.
+    should specify a transform for the variable, e.g.
     ``pymc.distributions.transforms.log`` for standard
     deviation posterior.
 

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -162,7 +162,7 @@ def prior_from_idata(
     ...         c=transforms.log,       # apply log transform to a positive variable
     ...                                 # similar to dict(transform=transforms.log)
     ...
-    ...                                 # set a name, assign a coord and apply simplex transform
+    ...                                 # set a name, assign a dim and apply simplex transform
     ...         f=dict(name="new_f", dims="options", transform=transforms.simplex)
     ...     )
     ...     trace1 = pm.sample_prior_predictive(100)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -1,11 +1,29 @@
-from typing import TypedDict, Optional, Union, Tuple, Sequence, Dict
+from typing import TypedDict, Optional, Union, Tuple, Sequence, Dict, List
 import aeppl.transforms
+import arviz
+import numpy as np
 
 
 class ParamCfg(TypedDict):
     name: str
     transform: Optional[aeppl.transforms.RVTransform]
     dims: Optional[Union[str, Tuple[str]]]
+
+
+class ShapeInfo(TypedDict):
+    # shape might not match slice due to a transform
+    shape: Tuple[int]
+    slice: slice
+
+
+class VarInfo(TypedDict):
+    sinfo: ShapeInfo
+    vinfo: ParamCfg
+
+
+class FlatInfo(TypedDict):
+    data: np.ndarray
+    info: List[VarInfo]
 
 
 def _arg_to_param_cfg(
@@ -36,3 +54,23 @@ def _parse_args(
     for key, val in kwargs.items():
         results[key] = _arg_to_param_cfg(key, val)
     return results
+
+
+def _flatten(idata: arviz.InferenceData, **kwargs: ParamCfg) -> FlatInfo:
+    posterior = idata.posterior
+    vars = list()
+    info = list()
+    begin = 0
+    for key, cfg in kwargs.items():
+        data = posterior[key].values
+        # omitting chain, draw
+        shape = data.shape[2:]
+        if cfg["transform"] is not None:
+            data = cfg["transform"].forward(data).eval()
+        data = data.reshape(*data.shape[:2], -1)
+        data = data.reshape(-1, data.shape[2])
+        end = begin + data.shape[1]
+        vars.append(data)
+        info.append(dict(shape=shape, slice=slice(begin, end)))
+        begin = end
+    return dict(data=np.concatenate(vars, axis=-1), infp=info)

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -156,7 +156,7 @@ def prior_from_idata(
     ...         e="new_e",              # assign new name "new_e" for a variable
     ...                                 # similar to dict(name="new_e")
     ...
-    ...         b=("test", ),           # set a coord to "test"
+    ...         b=("test", ),           # set a dim to "test"
     ...                                 # similar to dict(dims=("test", ))
     ...
     ...         c=transforms.log,       # apply log transform to a positive variable


### PR DESCRIPTION
If you want to do knowledge transfer in a smart way, this is how you do this

```python
from pymc.distributions import transforms

with model1:
    trace = pm.sample()
    # trace.posterior.keys() ~ ["a", "b", "c", "d", "f", "g"]
    # a - vector
    # b - matrix
    # c - positive
    # d, f, g - some other variable we do not care about


with pm.Model(coords=dict(test=range(3))) as model:
    priors = pmx.utils.prior.prior_from_idata(
        trace, 
        var_names=["a"],
        b=("test", "test"),
        c=transforms.log, 
        d="e", 
        f=dict(dims="test"),
        g=dict(name="h", dims="test", transform=transforms.log)
    )
    # 0. do nothing special to 'a' and other items in "var_names"
    # 1. 'b' has coords ("test", "test")
    # 2. transform 'c' to logspace
    # 3. rename 'd' to 'e'
    # 4. say 'f' has coords 'test'
    # 5. do everything mentioned with 'g'
    # priors will be a dictionary with all the priors, variables are available by final name keys
```