### PR TITLE
Make pytest fail on uncaught warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    error
+    ignore:.*?(\b(pkg_resources\.declare_namespace)\b).*:DeprecationWarning
+    ignore::UserWarning:arviz.data.inference_data


### PR DESCRIPTION
introduced config file (pytest.ini) in a root of the repository, added configuration failing tests if containing uncaught warnings. Added ignores for already known and ofter appearing warnings that won't be resolved in the near future 
(namespace deprecation warning and arviz inference data warning that warns about inference data not being registered in InferenceData scheme