### PR TITLE
Return posterior predictive samples from all chains

### DIFF
--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -23,6 +23,7 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
+import xarray as xr
 
 
 class ModelBuilder:
@@ -244,11 +245,52 @@ class ModelBuilder:
         self.idata.add_groups(fit_data=self.data.to_xarray())
         return self.idata
 
+    def predict_posterior(
+        self,
+        data_prediction: Dict[str, Union[np.ndarray, pd.DataFrame, pd.Series]] = None,
+        extend_idata: bool = True,
+    ) -> xr.Dataset:
+        """
+        Generate posterior predictive samples on unseen data.
+
+        Parameters
+        ---------
+        data_prediction : Dictionary of string and either of numpy array, pandas dataframe or pandas Series
+            It is the data we need to make prediction on using the model.
+        extend_idata : Boolean determining whether the predictions should be added to inference data object.
+            Defaults to True.
+
+        Returns
+        -------
+        returns posterior predictive samples
+
+        Examples
+        --------
+        >>> data, model_config, sampler_config = LinearModel.create_sample_input()
+        >>> model = LinearModel(model_config, sampler_config)
+        >>> idata = model.fit(data)
+        >>> x_pred = []
+        >>> prediction_data = pd.DataFrame({'input': x_pred})
+        >>> pred_samples = model.predict_posterior(prediction_data)
+        """
+
+        if data_prediction is not None:  # set new input data
+            self._data_setter(data_prediction)
+
+        with self.model:  # sample with new input data
+            post_pred = pm.sample_posterior_predictive(self.idata)
+            if extend_idata:
+                self.idata.extend(post_pred)
+
+        posterior_predictive_samples = az.extract(post_pred, "posterior_predictive", combined=False)
+
+        return posterior_predictive_samples
+
     def predict(
         self,
         data_prediction: Dict[str, Union[np.ndarray, pd.DataFrame, pd.Series]] = None,
         extend_idata: bool = True,
-    ) -> dict:
+    ) -> xr.Dataset:
         """
         Uses model to predict on unseen data and return point prediction of all the samples
 
@@ -261,7 +303,7 @@ class ModelBuilder:
 
         Returns
         -------
-        returns dictionary of sample's mean of posterior predict.
+        returns posterior mean of predictive samples
 
         Examples
         --------
@@ -270,86 +312,11 @@ class ModelBuilder:
         >>> idata = model.fit(data)
         >>> x_pred = []
         >>> prediction_data = pd.DataFrame({'input':x_pred})
-        # point predict
         >>> pred_mean = model.predict(prediction_data)
         """
-
-        if data_prediction is not None:  # set new input data
-            self._data_setter(data_prediction)
-
-        with self.model:  # sample with new input data
-            post_pred = pm.sample_posterior_predictive(self.idata)
-            if extend_idata:
-                self.idata.extend(post_pred)
-        # reshape output
-        post_pred = self._extract_samples(post_pred)
-        for key in post_pred:
-            post_pred[key] = post_pred[key].mean(axis=0)
-
-        return post_pred
-
-    def predict_posterior(
-        self,
-        data_prediction: Dict[str, Union[np.ndarray, pd.DataFrame, pd.Series]] = None,
-        extend_idata: bool = True,
-    ) -> Dict[str, np.array]:
-        """
-        Uses model to predict samples on unseen data.
-
-        Parameters
-        ---------
-        data_prediction : Dictionary of string and either of numpy array, pandas dataframe or pandas Series
-            It is the data we need to make prediction on using the model.
-        extend_idata : Boolean determining whether the predictions should be added to inference data object.
-            Defaults to True.
-
-        Returns
-        -------
-        returns dictionary of sample's posterior predict.
-
-        Examples
-        --------
-        >>> data, model_config, sampler_config = LinearModel.create_sample_input()
-        >>> model = LinearModel(model_config, sampler_config)
-        >>> idata = model.fit(data)
-        >>> x_pred = []
-        >>> prediction_data = pd.DataFrame({'input': x_pred})
-        # samples
-        >>> pred_mean = model.predict_posterior(prediction_data)
-        """
-
-        if data_prediction is not None:  # set new input data
-            self._data_setter(data_prediction)
-
-        with self.model:  # sample with new input data
-            post_pred = pm.sample_posterior_predictive(self.idata)
-            if extend_idata:
-                self.idata.extend(post_pred)
-
-        # reshape output
-        post_pred = self._extract_samples(post_pred)
-
-        return post_pred
-
-    @staticmethod
-    def _extract_samples(post_pred: az.data.inference_data.InferenceData) -> Dict[str, np.array]:
-        """
-        This method can be used to extract samples from posterior predict.
-
-        Parameters
-        ----------
-        post_pred: arviz InferenceData object
-
-        Returns
-        -------
-        Dictionary of numpy arrays from InferenceData object
-        """
-
-        post_pred_dict = dict()
-        for key in post_pred.posterior_predictive:
-            post_pred_dict[key] = post_pred.posterior_predictive[key].to_numpy()[0]
-
-        return post_pred_dict
+        posterior_predictive_samples = self.predict_posterior(data_prediction, extend_idata)
+        posterior_means = posterior_predictive_samples.mean(dim=["chain", "draw"])
+        return posterior_means
 
     @property
     def id(self) -> str:

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -29,7 +29,6 @@ class test_ModelBuilder(ModelBuilder):
     version = "0.1"
 
     def build(self):
-
         with pm.Model() as self.model:
             if self.data is not None:
                 x = pm.MutableData("x", self.data["input"].values)
@@ -148,40 +147,21 @@ def test_predict():
     prediction_data = pd.DataFrame({"input": x_pred})
     pred = model.predict(prediction_data)
     assert "y_model" in pred
-    assert isinstance(pred, dict)
     assert len(prediction_data.input.values) == len(pred["y_model"])
-    assert isinstance(pred["y_model"][0], (np.float32, np.float64))
+    assert np.issubdtype(pred["y_model"].dtype, np.floating)
 
 
 def test_predict_posterior():
     model = test_ModelBuilder.initial_build_and_fit()
-    x_pred = np.random.uniform(low=0, high=1, size=100)
+    n_pred = 100
+    x_pred = np.random.uniform(low=0, high=1, size=n_pred)
     prediction_data = pd.DataFrame({"input": x_pred})
     pred = model.predict_posterior(prediction_data)
+    chains = model.idata.sample_stats.dims["chain"]
+    draws = model.idata.sample_stats.dims["draw"]
     assert "y_model" in pred
-    assert isinstance(pred, dict)
-    assert len(prediction_data.input.values) == len(pred["y_model"][0])
-    assert isinstance(pred["y_model"][0], np.ndarray)
-
-
-def test_extract_samples():
-    # create a fake InferenceData object
-    with pm.Model() as model:
-        x = pm.Normal("x", mu=0, sigma=1)
-        intercept = pm.Normal("intercept", mu=0, sigma=1)
-        y_model = pm.Normal("y_model", mu=x * intercept, sigma=1, observed=[0, 1, 2])
-
-        idata = pm.sample(1000, tune=1000)
-        post_pred = pm.sample_posterior_predictive(idata)
-
-    # call the function and get the output
-    samples_dict = test_ModelBuilder._extract_samples(post_pred)
-
-    # assert that the keys and values are correct
-    assert len(samples_dict) == len(post_pred.posterior_predictive)
-    for key in post_pred.posterior_predictive:
-        expected_value = post_pred.posterior_predictive[key].to_numpy()[0]
-        assert np.array_equal(samples_dict[key], expected_value)
+    assert pred["y_model"].shape == (chains, draws, n_pred)
+    assert np.issubdtype(pred["y_model"].dtype, np.floating)
 
 
 def test_id():


### PR DESCRIPTION
This fixes a bug where only values from one chain were returned. It also refactors the prediction logic to reduce duplication. I've used `arviz.extract()` to get the posterior predictive samples as hinted by @twiecki  in #139, removing the `_extract_samples()` method from the model builder class. 

**Behavior change proposal**

This PR also includes a proposed behavior change that makes the output of `predict_posterior()` consistent in type and shape with the output of `pymc.sample_posterior_predictive()`. 

Namely, `predict_posterior()` would here return an xarray Dataset from the posterior predictive distribution, rather than a dictionary of numpy arrays. This is an admittedly opinionated change in behavior, though it does also streamline the code. From my perspective, retaining the metadata related to chains, draws, and other attributes is useful for two key reasons: 

1. downstream processing for posterior predictive checks, enabling easier alignment of chains and draws with other pushforward quantities, and
2. tracking the provenance of predictions (e.g., creation time and package versions attributes) in a production environment

That said, I'm very open to other perspectives on how to bundle up posterior predictive samples.