### PR TITLE
removed unused *args from fit, added named args to sampler_config

### DIFF
--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -235,7 +235,6 @@ class ModelBuilder:
         progressbar: bool = True,
         random_seed: RandomState = None,
         data: Dict[str, Union[np.ndarray, pd.DataFrame, pd.Series]] = None,
-        *args: Any,
         **kwargs: Any,
     ) -> az.InferenceData:
         """
@@ -269,6 +268,10 @@ class ModelBuilder:
         if self.sampler_config is None:
             self.sampler_config = sampler_config
         self.build_model(self.model_data, self.model_config)
+
+        sampler_config["progressbar"] = progressbar
+        sampler_config["random_seed"] = random_seed
+
         with self.model:
             self.idata = pm.sample(**self.sampler_config, **kwargs)
             self.idata.extend(pm.sample_prior_predictive())


### PR DESCRIPTION
I noticed that named parameters added in last model_builder PR were not added in the sampler_config during fit() execution, 
which would result in them not being preserved in the saved version of the model. This PR fixes this