### PR TITLE
replacing slicing in git actions with python slicing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,7 +30,7 @@ jobs:
             venv-sdist/bin/python -m pip install numpy
             venv-sdist/bin/python -m pip install ../dist/pymc-experimental*.tar.gz
             echo "Checking import and version number (on release)"
-            venv-sdist/bin/python -c "import pymc_experimental as pmx; assert pmx.__version__ == 'v${{ github.ref_name[1:] }}' if '${{ github.ref_type }}' == 'tag' else True; print(pmx.__version__)"
+            venv-sdist/bin/python -c "import pymc_experimental as pmx; assert pmx.__version__ == '${{ github.ref_name }}'[1:] if '${{ github.ref_type }}' == 'tag' else True; print(pmx.__version__)"
             cd ..
       - name: Check the bdist installs and imports
         run: |
@@ -39,7 +39,7 @@ jobs:
               python -m venv venv-bdist
               venv-bdist/bin/python -m pip install ../dist/pymc_experimental*.whl
               echo "Checking import and version number (on release)"
-              venv-bdist/bin/python -c "import pymc_experimental as pmx; assert pmx.__version__ == '${{ github.ref_name[1:] }}' if '${{ github.ref_type }}' == 'tag' else pmx.__version__; print(pmx.__version__)"
+              venv-bdist/bin/python -c "import pymc_experimental as pmx; assert pmx.__version__ == '${{ github.ref_name }}'[1:] if '${{ github.ref_type }}' == 'tag' else pmx.__version__; print(pmx.__version__)"
               cd ..
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
GitHub Actions doesn't yet support the slicing operations, therefore the slicing needs to be used after retrieving the github.ref_name for comparison.