### PR TITLE
Implement limit case of R2D2M2CP for P

### DIFF
--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -394,7 +394,9 @@ def R2D2M2CP(
     *broadcast_dims, dim = dims
     input_sigma = pt.as_tensor(input_sigma)
     output_sigma = pt.as_tensor(output_sigma)
-    with pm.Model(name):
+    with pm.Model(name) as model:
+        if not all(isinstance(model.dim_lengths[d], pt.TensorConstant) for d in dims):
+            raise ValueError(f"{dims!r} should be constant length imutable dims")
         if r2_std is not None:
             r2 = pm.Beta("r2", mu=r2, sigma=r2_std, dims=broadcast_dims)
         phi = _phi(

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -29,7 +29,7 @@ def _psivar2musigma(psi: pt.TensorVariable, explained_var: pt.TensorVariable, ps
     mu = sigma * pi * 2**0.5
     if psi_mask is not None:
         return (
-            pt.where(psi_mask, mu, explained_var**0.5),
+            pt.where(psi_mask, mu, pt.sign(mu) * explained_var**0.5),
             pt.where(psi_mask, sigma, 0),
         )
     else:

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -396,7 +396,7 @@ def R2D2M2CP(
     output_sigma = pt.as_tensor(output_sigma)
     with pm.Model(name) as model:
         if not all(isinstance(model.dim_lengths[d], pt.TensorConstant) for d in dims):
-            raise ValueError(f"{dims!r} should be constant length imutable dims")
+            raise ValueError(f"{dims!r} should be constant length immutable dims")
         if r2_std is not None:
             r2 = pm.Beta("r2", mu=r2, sigma=r2_std, dims=broadcast_dims)
         phi = _phi(

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -29,7 +29,7 @@ def _psivar2musigma(psi: pt.TensorVariable, explained_var: pt.TensorVariable, ps
     mu = sigma * pi * 2**0.5
     if psi_mask is not None:
         return (
-            pt.where(psi_mask, mu, pt.sign(mu) * explained_var**0.5),
+            pt.where(psi_mask, mu, pt.sign(pi) * explained_var**0.5),
             pt.where(psi_mask, sigma, 0),
         )
     else:

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -382,6 +382,7 @@ def R2D2M2CP(
             variables_importance=variables_importance,
             variance_explained=variance_explained,
             importance_concentration=importance_concentration,
+            dims=dims,
         )
         mask, psi = _psi(
             positive_probs=positive_probs, positive_probs_std=positive_probs_std, dims=dims

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -381,6 +381,7 @@ def R2D2M2CP(
         phi = _phi(
             variables_importance=variables_importance,
             variance_explained=variance_explained,
+            importance_concentration=importance_concentration,
         )
         mask, psi = _psi(
             positive_probs=positive_probs, positive_probs_std=positive_probs_std, dims=dims

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -182,6 +182,25 @@ class TestR2D2M2CP:
                 variables_importance=[1, 1],
             )
 
-    def test_limit_case_requires_std_0(self):
-        # TODO: add test for the limit cases that assertions work as expected
-        return
+    def test_limit_case_requires_std_0(self, model: pm.Model):
+        model.add_coord("a", range(2))
+        with pytest.raises(ValueError, match="Can't have both positive_probs"):
+            pmx.distributions.R2D2M2CP(
+                "beta",
+                1,
+                [1, 1],
+                dims="a",
+                r2=0.8,
+                positive_probs=[0.5, 0],
+                positive_probs_std=[0.3, 0.1],
+            )
+        with pytest.raises(ValueError, match="Can't have both positive_probs"):
+            pmx.distributions.R2D2M2CP(
+                "beta",
+                1,
+                [1, 1],
+                dims="a",
+                r2=0.8,
+                positive_probs=[0.5, 1],
+                positive_probs_std=[0.3, 0.1],
+            )

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pymc as pm
+import pytensor
 import pytest
 
 import pymc_experimental as pmx
@@ -95,6 +96,10 @@ class TestR2D2M2CP:
             phi_args_base["importance_concentration"] = 10
         return phi_args_base
 
+    @pytest.mark.skipif(
+        pytensor.config.floatX == "float32",
+        reason="pytensor.config.floatX == 'float32', https://github.com/pymc-devs/pymc/issues/6779",
+    )
     def test_init(
         self,
         dims,
@@ -133,7 +138,7 @@ class TestR2D2M2CP:
         assert ("beta::psi" in model.named_vars) == (
             positive_probs_std is not None and positive_probs_std.any()
         ), set(model.named_vars)
-        assert np.isfinite(sum(model.point_logps().values())), model.point_logps()
+        assert np.isfinite(sum(model.point_logps().values()))
 
     def test_failing_importance(self, dims, input_shape, output_std, input_std):
         if input_shape[-1] < 2:

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -255,3 +255,27 @@ class TestR2D2M2CP:
             "b2", 1, [1, 1], r2=0.5, positive_probs=[1, 1], positive_probs_std=[0, 0], dims="a"
         )
         assert not model.free_RVs, model.free_RVs
+
+    def test_immutable_dims(self, model: pm.Model):
+        model.add_coord("a", range(2), mutable=True)
+        model.add_coord("b", range(2), mutable=False)
+        with pytest.raises(ValueError, match="should be constant length immutable dims"):
+            pmx.distributions.R2D2M2CP(
+                "beta0",
+                1,
+                [1, 1],
+                dims="a",
+                r2=0.8,
+                positive_probs=[0.5, 1],
+                positive_probs_std=[0.3, 0],
+            )
+        with pytest.raises(ValueError, match="should be constant length immutable dims"):
+            pmx.distributions.R2D2M2CP(
+                "beta0",
+                1,
+                [1, 1],
+                dims=("a", "b"),
+                r2=0.8,
+                positive_probs=[0.5, 1],
+                positive_probs_std=[0.3, 0],
+            )

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -236,3 +236,14 @@ class TestR2D2M2CP:
             assert "beta1::masked" in model.named_vars, model.named_vars
         assert "beta1::psi::masked" in model.named_vars
         assert "beta0::psi::masked" in model.named_vars
+
+    def test_zero_length_rvs_not_created(self, model: pm.Model):
+        model.add_coord("a", range(2))
+        # deterministic case which should not have any new variables
+        b = pmx.distributions.R2D2M2CP("b1", 1, [1, 1], r2=0.5, positive_probs=[1, 1], dims="a")
+        assert not model.free_RVs, model.free_RVs
+
+        b = pmx.distributions.R2D2M2CP(
+            "b2", 1, [1, 1], r2=0.5, positive_probs=[1, 1], positive_probs_std=[0, 0], dims="a"
+        )
+        assert not model.free_RVs, model.free_RVs

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -118,6 +118,7 @@ class TestR2D2M2CP:
             positive_probs=positive_probs,
             **phi_args
         )
+        assert not np.isnan(beta.eval()).any()
         assert eps.eval().shape == output_std.shape
         assert beta.eval().shape == input_std.shape
         # r2 rv is only created if r2 std is not None


### PR DESCRIPTION
close #170 to enable strict coefficient sign in the model


```python
with pm.Model(coords=dict(a=range(2))) as model:
    std, beta = pmx.distributions.R2D2M2CP(
        "beta1",
        1,
        [1, 1],
        dims="a",
        r2=0.8,
        r2_std=0.1,
        positive_probs=[0.5, 0],
        positive_probs_std=[0.3, 0],
        centered=False,
    )
```
<img width="680" alt="image" src="https://github.com/pymc-devs/pymc-experimental/assets/11705326/da1938b9-06a9-4d0e-9d66-7da219cce3a6">
