### PR TITLE
Refactor modelbuilder fit

### DIFF
--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -24,6 +24,8 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import xarray as xr
+from pymc.backends import NDArray
+from pymc.backends.base import MultiTrace
 from pymc.util import RandomState
 
 # If scikit-learn is available, use its data validator
@@ -425,6 +427,36 @@ class ModelBuilder:
         self,
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
+        fit_method="mcmc",
+        **kwargs: Any,
+    ) -> az.InferenceData:
+        """
+        Fit a model using the data passed as a parameter.
+        Sets attrs to inference data of the model.
+
+
+        Parameters
+        ----------
+        X : array-like if sklearn is available, otherwise array, shape (n_obs, n_features)
+            The training input samples.
+        y : array-like if sklearn is available, otherwise array, shape (n_obs,)
+            The target values (real numbers).
+        fit_method : str
+            Which method to use to infer model parameters. One of ["mcmc", "MAP"].
+        **kwargs : Any
+            Parameters to pass to the inference method. See `_fit_mcmc` or `_fit_MAP` for
+            method-specific parameters.
+        """
+        if fit_method == "mcmc":
+            return self._fit_mcmc(X, y, **kwargs)
+        if fit_method == "MAP":
+            return self._fit_MAP(X, y, **kwargs)
+        raise ValueError(f"Inference method {fit_method} not found. Choose one of ['mcmc', 'MAP'].")
+
+    def _fit_mcmc(
+        self,
+        X: pd.DataFrame,
+        y: Optional[pd.Series] = None,
         progressbar: bool = True,
         predictor_names: List[str] = None,
         random_seed: RandomState = None,
@@ -481,6 +513,44 @@ class ModelBuilder:
         assert all(combined_data.columns), "All columns must have non-empty names"
         self.idata.add_groups(fit_data=combined_data.to_xarray())  # type: ignore
         return self.idata  # type: ignore
+
+    def _fit_MAP(
+        self,
+        X: pd.DataFrame,
+        y: Optional[pd.Series] = None,
+        predictor_names: List[str] = None,
+        **kwargs,
+    ):
+        """Find model maximum a posteriori using scipy optimizer"""
+
+        if predictor_names is None:
+            predictor_names = []
+        if y is None:
+            y = np.zeros(X.shape[0])
+        y = pd.DataFrame({self.output_var: y})
+        self.generate_and_preprocess_model_data(X, y.values.flatten())
+        self.build_model(self.X, self.y)
+        model = self.model
+
+        map_res = pm.find_MAP(model=model, **kwargs)
+        # Filter non-value variables
+        value_vars_names = {v.name for v in model.value_vars}
+        map_res = {k: v for k, v in map_res.items() if k in value_vars_names}
+
+        # Convert map result to InferenceData
+        map_strace = NDArray(model=model)
+        map_strace.setup(draws=1, chain=0)
+        map_strace.record(map_res)
+        map_strace.close()
+        trace = MultiTrace([map_strace])
+        self.idata = pm.to_inference_data(trace, model=model)
+        self.set_idata_attrs(self.idata)
+
+        X_df = pd.DataFrame(X, columns=X.columns)
+        combined_data = pd.concat([X_df, y], axis=1)
+        assert all(combined_data.columns), "All columns must have non-empty names"
+        self.idata.add_groups(fit_data=combined_data.to_xarray())  # type: ignore
+        return self.idata
 
     def predict(
         self,

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -163,9 +163,9 @@ def test_fit_no_y(toy_X, fit_method):
     sys.platform == "win32", reason="Permissions for temp files not granted on windows CI."
 )
 def test_save_load(fitted_model_instance):
-    temp = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
-    fitted_model_instance.save(temp.name)
-    test_builder2 = test_ModelBuilder.load(temp.name)
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as temp:
+        fitted_model_instance.save(temp.name)
+        test_builder2 = test_ModelBuilder.load(temp.name)
     assert sorted(fitted_model_instance.idata.groups()) == sorted(test_builder2.idata.groups())
 
     x_pred = np.random.uniform(low=0, high=1, size=100)
@@ -173,7 +173,6 @@ def test_save_load(fitted_model_instance):
     pred1 = fitted_model_instance.predict(prediction_data["input"])
     pred2 = test_builder2.predict(prediction_data["input"])
     assert pred1.shape == pred2.shape
-    temp.close()
 
 
 def test_predict(fitted_model_instance):

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -40,8 +40,8 @@ def toy_y(toy_X):
     return y
 
 
-@pytest.fixture(scope="module")
-def fitted_model_instance(toy_X, toy_y):
+@pytest.fixture(scope="module", params=["mcmc", "MAP"])
+def fitted_model_instance(request, toy_X, toy_y):
     sampler_config = {
         "draws": 500,
         "tune": 300,
@@ -54,12 +54,11 @@ def fitted_model_instance(toy_X, toy_y):
         "obs_error": 2,
     }
     model = test_ModelBuilder(model_config=model_config, sampler_config=sampler_config)
-    model.fit(toy_X)
+    model.fit(toy_X, toy_y, fit_method=request.param)
     return model
 
 
 class test_ModelBuilder(ModelBuilder):
-
     _model_type = "LinearModel"
     version = "0.1"
 
@@ -151,9 +150,10 @@ def test_fit(fitted_model_instance):
     post_pred[fitted_model_instance.output_var].shape[0] == prediction_data.input.shape
 
 
-def test_fit_no_y(toy_X):
+@pytest.mark.parametrize("fit_method", ["mcmc", "MAP"])
+def test_fit_no_y(toy_X, fit_method):
     model_builder = test_ModelBuilder()
-    model_builder.idata = model_builder.fit(X=toy_X)
+    model_builder.idata = model_builder.fit(X=toy_X, fit_method=fit_method)
     assert model_builder.model is not None
     assert model_builder.idata is not None
     assert "posterior" in model_builder.idata.groups()
@@ -166,7 +166,7 @@ def test_save_load(fitted_model_instance):
     temp = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
     fitted_model_instance.save(temp.name)
     test_builder2 = test_ModelBuilder.load(temp.name)
-    assert fitted_model_instance.idata.groups() == test_builder2.idata.groups()
+    assert sorted(fitted_model_instance.idata.groups()) == sorted(test_builder2.idata.groups())
 
     x_pred = np.random.uniform(low=0, high=1, size=100)
     prediction_data = pd.DataFrame({"input": x_pred})
@@ -193,8 +193,8 @@ def test_sample_posterior_predictive(fitted_model_instance, combined):
     pred = fitted_model_instance.sample_posterior_predictive(
         prediction_data["input"], combined=combined, extend_idata=True
     )
-    chains = fitted_model_instance.idata.sample_stats.dims["chain"]
-    draws = fitted_model_instance.idata.sample_stats.dims["draw"]
+    chains = fitted_model_instance.idata.posterior.dims["chain"]
+    draws = fitted_model_instance.idata.posterior.dims["draw"]
     expected_shape = (n_pred, chains * draws) if combined else (chains, draws, n_pred)
     assert pred[fitted_model_instance.output_var].shape == expected_shape
     assert np.issubdtype(pred[fitted_model_instance.output_var].dtype, np.floating)


### PR DESCRIPTION
In response to #196, I made an attempt at the refactoring.

The first commit naively duplicates the existing `fit` function for both mcmc and find_MAP fitting methods. The fourth commit puts some of the setup and cleanup code back in the `fit` function and switches only the actual inference part. I didn't know which way the team might prefer, so they're both there.

I considered making an `Enum` for the fitting methods, but I saw that `pymc.sampling.sample()` uses `str`, so that's what I did here.

I don't feel great about the handling of `sampler_config` arguments here. There is some overlap in args to mcmc `sample_*` and `find_MAP`, but some args are different. At least `scipy.optimize.minimize` doesn't accept extraneous kwargs, so I pass through only whitelisted args to `find_MAP`.