### PR TITLE
Copy model-related shared variables in `model_fgraph`

### DIFF
--- a/pymc_experimental/tests/utils/test_model_fgraph.py
+++ b/pymc_experimental/tests/utils/test_model_fgraph.py
@@ -118,7 +118,7 @@ def test_data(inline_views):
     assert m_new.rvs_to_values[m_new["obs"]] is m_new["y"]
 
     # Shared rng shared variables are not preserved
-    m_new["b1"].owner.inputs[0].container is not m_old["b1"].owner.inputs[0].container
+    assert m_new["b1"].owner.inputs[0].container is not m_old["b1"].owner.inputs[0].container
 
     with m_old:
         pm.set_data({"x": [100.0, 200.0]}, coords={"test_dim": range(2)})

--- a/pymc_experimental/utils/model_fgraph.py
+++ b/pymc_experimental/utils/model_fgraph.py
@@ -4,7 +4,7 @@ import pytensor
 from pymc.logprob.transforms import RVTransform
 from pymc.model import Model
 from pymc.pytensorf import find_rng_nodes
-from pytensor import Variable
+from pytensor import Variable, shared
 from pytensor.graph import Apply, FunctionGraph, Op, node_rewriter
 from pytensor.graph.rewriting.basic import out2in
 from pytensor.scalar import Identity
@@ -184,8 +184,7 @@ def fgraph_from_model(
 
     # Replace RNG nodes so that seeding does not interfere with old model
     for rng in find_rng_nodes(model_vars):
-        new_rng = rng.clone()
-        new_rng.set_value(rng.get_value(borrow=False))
+        new_rng = shared(rng.get_value(borrow=False))
         memo[rng] = new_rng
 
     fgraph = FunctionGraph(


### PR DESCRIPTION
In earlier iterations of the do-blogpost it became clear that it's more intuitive for model-related shared variables to be copied, instead of shared across different models. Some of these variables are created by PyMC (dim_lengths) and users would have to know the internals not to be surprised about the behavior.

User defined `MutableData` is also copied, because unlike the underlying `SharedVariable`s, nothing about the name and documentation suggests these variables are supposed to be "shared" across models (just that they can be mutated).

I have only allowed user-defined shared variables that are *not* model variables to be actually shared across model cloning.

This now works as (imo) expected:

```python
import pymc as pm
from pymc_experimental.model_transform.conditioning import do

with pm.Model(coords_mutable={"i": [0]}) as m:
    x = pm.Normal("x")
    y = pm.Normal("y", x, dims=("i",))
    
new_m = do(m, {x: 0})
new_m.set_dim("i", new_length=5, coord_values=list(range(5)))

assert pm.draw(m["y"]).shape == (1,)  # Before this would also be (5,)
assert pm.draw(new_m["y"].shape) == (5,)
```

This PR also fixes a bug, as RNG shared variables weren't actually being copied and rendered independent with the old `clone` approach. The relevant test was missing an `assert` :( (see first commit of this PR)