### PR TITLE
renamed to _generate_and_preprocess_model_data

### DIFF
--- a/pymc_experimental/linearmodel.py
+++ b/pymc_experimental/linearmodel.py
@@ -100,7 +100,7 @@ class LinearModel(ModelBuilder):
             if y is not None:
                 pm.set_data({"y_data": y.squeeze()})
 
-    def generate_and_preprocess_model_data(
+    def _generate_and_preprocess_model_data(
         self, X: Union[pd.DataFrame, pd.Series], y: pd.Series
     ) -> None:
         """

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -205,7 +205,7 @@ class ModelBuilder:
         Examples
         --------
         >>>     @classmethod
-        >>>     def generate_and_preprocess_model_data(self, X, y):
+        >>>     def _generate_and_preprocess_model_data(self, X, y):
                     coords = {
                         'x_dim': X.dim_variable,
                     } #only include if applicable for your model
@@ -494,7 +494,7 @@ class ModelBuilder:
         if y is None:
             y = np.zeros(X.shape[0])
         y = pd.DataFrame({self.output_var: y})
-        self.generate_and_preprocess_model_data(X, y.values.flatten())
+        self._generate_and_preprocess_model_data(X, y.values.flatten())
         self.build_model(self.X, self.y)
 
         sampler_config = self.sampler_config.copy()

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -122,6 +122,12 @@ class test_ModelBuilder(ModelBuilder):
             "obs_error": 2,
         }
 
+    def _generate_and_preprocess_model_data(
+        self, X: pd.DataFrame | pd.Series, y: pd.Series
+    ) -> None:
+        self.X = X
+        self.y = y
+
     @property
     def default_sampler_config(self) -> Dict:
         return {

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -16,7 +16,7 @@ import hashlib
 import json
 import sys
 import tempfile
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -123,7 +123,7 @@ class test_ModelBuilder(ModelBuilder):
         }
 
     def _generate_and_preprocess_model_data(
-        self, X: pd.DataFrame | pd.Series, y: pd.Series
+        self, X: Union[pd.DataFrame, pd.Series], y: pd.Series
     ) -> None:
         self.X = X
         self.y = y


### PR DESCRIPTION
while renaming the abstract definition, the function call in fit() was left over with old name. This requires quick bug fix