### PR TITLE
Change default_*_config from @property to @staticmethod

### DIFF
--- a/pymc_experimental/linearmodel.py
+++ b/pymc_experimental/linearmodel.py
@@ -20,16 +20,16 @@ class LinearModel(ModelBuilder):
     _model_type = "LinearModel"
     version = "0.1"
 
-    @property
-    def default_model_config(self):
+    @classmethod
+    def get_default_model_config(self):
         return {
             "intercept": {"loc": 0, "scale": 10},
             "slope": {"loc": 0, "scale": 10},
             "obs_error": 2,
         }
 
-    @property
-    def default_sampler_config(self):
+    @classmethod
+    def get_default_sampler_config(self):
         return {
             "draws": 1_000,
             "tune": 1_000,

--- a/pymc_experimental/linearmodel.py
+++ b/pymc_experimental/linearmodel.py
@@ -20,16 +20,16 @@ class LinearModel(ModelBuilder):
     _model_type = "LinearModel"
     version = "0.1"
 
-    @classmethod
-    def get_default_model_config(self):
+    @staticmethod
+    def get_default_model_config():
         return {
             "intercept": {"loc": 0, "scale": 10},
             "slope": {"loc": 0, "scale": 10},
             "obs_error": 2,
         }
 
-    @classmethod
-    def get_default_sampler_config(self):
+    @staticmethod
+    def get_default_sampler_config():
         return {
             "draws": 1_000,
             "tune": 1_000,

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -135,17 +135,17 @@ class ModelBuilder:
         """
         raise NotImplementedError
 
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def get_default_model_config(self) -> Dict:
+    def get_default_model_config() -> Dict:
         """
         Returns a class default config dict for model builder if no model_config is provided on class initialization
         Useful for understanding structure of required model_config to allow its customization by users
         Examples
         --------
-        >>>     @classmethod
-        >>>     def default_model_config(self):
-        >>>         Return {
+        >>>     @staticmethod
+        >>>     def default_model_config():
+        >>>         return {
         >>>             'a' : {
         >>>                 'loc': 7,
         >>>                 'scale' : 3
@@ -164,7 +164,7 @@ class ModelBuilder:
         """
         raise NotImplementedError
 
-    @classmethod
+    @staticmethod
     @abstractmethod
     def get_default_sampler_config(self) -> Dict:
         """
@@ -172,9 +172,9 @@ class ModelBuilder:
         Useful for understanding structure of required sampler_config to allow its customization by users
         Examples
         --------
-        >>>     @classmethod
-        >>>     def default_sampler_config(self):
-        >>>         Return {
+        >>>     @staticmethod
+        >>>     def default_sampler_config():
+        >>>         return {
         >>>             'draws': 1_000,
         >>>             'tune': 1_000,
         >>>             'chains': 1,

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -71,9 +71,11 @@ class ModelBuilder:
         >>>     ...
         >>> model = MyModel(model_config, sampler_config)
         """
-        sampler_config = self.default_sampler_config if sampler_config is None else sampler_config
+        sampler_config = (
+            self.get_default_sampler_config() if sampler_config is None else sampler_config
+        )
         self.sampler_config = sampler_config
-        model_config = self.default_model_config if model_config is None else model_config
+        model_config = self.get_default_model_config() if model_config is None else model_config
 
         self.model_config = model_config  # parameters for priors etc.
         self.model = None  # Set by build_model
@@ -133,9 +135,9 @@ class ModelBuilder:
         """
         raise NotImplementedError
 
-    @property
+    @classmethod
     @abstractmethod
-    def default_model_config(self) -> Dict:
+    def get_default_model_config(self) -> Dict:
         """
         Returns a class default config dict for model builder if no model_config is provided on class initialization
         Useful for understanding structure of required model_config to allow its customization by users
@@ -162,9 +164,9 @@ class ModelBuilder:
         """
         raise NotImplementedError
 
-    @property
+    @classmethod
     @abstractmethod
-    def default_sampler_config(self) -> Dict:
+    def get_default_sampler_config(self) -> Dict:
         """
         Returns a class default sampler dict for model builder if no sampler_config is provided on class initialization
         Useful for understanding structure of required sampler_config to allow its customization by users

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -114,8 +114,8 @@ class test_ModelBuilder(ModelBuilder):
         self.X = X
         self.y = y
 
-    @classmethod
-    def get_default_model_config(self) -> Dict:
+    @staticmethod
+    def get_default_model_config() -> Dict:
         return {
             "a": {"loc": 0, "scale": 10, "dims": ("numbers",)},
             "b": {"loc": 0, "scale": 10},
@@ -128,8 +128,8 @@ class test_ModelBuilder(ModelBuilder):
         self.X = X
         self.y = y
 
-    @classmethod
-    def get_default_sampler_config(self) -> Dict:
+    @staticmethod
+    def get_default_sampler_config() -> Dict:
         return {
             "draws": 1_000,
             "tune": 1_000,

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -74,7 +74,7 @@ class test_ModelBuilder(ModelBuilder):
         self.generate_and_preprocess_model_data(X, y)
         with pm.Model(coords=coords) as self.model:
             if model_config is None:
-                model_config = self.default_model_config
+                model_config = self.model_config
             x = pm.MutableData("x", self.X["input"].values)
             y_data = pm.MutableData("y_data", self.y)
 
@@ -114,8 +114,8 @@ class test_ModelBuilder(ModelBuilder):
         self.X = X
         self.y = y
 
-    @property
-    def default_model_config(self) -> Dict:
+    @classmethod
+    def get_default_model_config(self) -> Dict:
         return {
             "a": {"loc": 0, "scale": 10, "dims": ("numbers",)},
             "b": {"loc": 0, "scale": 10},
@@ -128,8 +128,8 @@ class test_ModelBuilder(ModelBuilder):
         self.X = X
         self.y = y
 
-    @property
-    def default_sampler_config(self) -> Dict:
+    @classmethod
+    def get_default_sampler_config(self) -> Dict:
         return {
             "draws": 1_000,
             "tune": 1_000,


### PR DESCRIPTION
Fixes #225. Since the method changed from a property to a method, it was renamed from a noun to a verb. Both `default_model_config` and `default_sampler_config` were changed.