### PR TITLE
Implement Chi distribution helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        floatx: [float64]
         python-version: ["3.9"]
         test-subset:
           - pymc_experimental/tests
@@ -26,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
+      PYTENSOR_FLAGS: gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}
@@ -77,13 +76,12 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: ${{ matrix.os }}
           fail_ci_if_error: false
   windows:
     strategy:
       matrix:
         os: [windows-latest]
-        floatx: [float32]
         python-version: ["3.11"]
         test-subset:
           - pymc_experimental/tests
@@ -91,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=core2'
+      PYTENSOR_FLAGS: gcc__cxxflags='-march=core2'
     defaults:
       run:
         shell: cmd
@@ -144,5 +142,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: ${{ matrix.os }}
           fail_ci_if_error: false

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -28,9 +28,10 @@ Distributions
 .. autosummary::
    :toctree: generated/
 
-   GenExtreme
-   GeneralizedPoisson
+   Chi
    DiscreteMarkovChain
+   GeneralizedPoisson
+   GenExtreme
    R2D2M2CP
    histogram_approximation
 

--- a/pymc_experimental/distributions/__init__.py
+++ b/pymc_experimental/distributions/__init__.py
@@ -17,7 +17,7 @@
 Experimental probability distributions for stochastic nodes in PyMC.
 """
 
-from pymc_experimental.distributions.continuous import GenExtreme
+from pymc_experimental.distributions.continuous import Chi, GenExtreme
 from pymc_experimental.distributions.discrete import GeneralizedPoisson
 from pymc_experimental.distributions.histogram_utils import histogram_approximation
 from pymc_experimental.distributions.multivariate import R2D2M2CP
@@ -29,4 +29,5 @@ __all__ = [
     "GenExtreme",
     "R2D2M2CP",
     "histogram_approximation",
+    "Chi",
 ]

--- a/pymc_experimental/tests/distributions/test_continuous.py
+++ b/pymc_experimental/tests/distributions/test_continuous.py
@@ -26,6 +26,7 @@ from pymc.testing import (
     BaseTestDistributionRandom,
     Domain,
     R,
+    Rplus,
     Rplusbig,
     assert_moment_is_expected,
     check_logcdf,
@@ -35,7 +36,7 @@ from pymc.testing import (
 )
 
 # the distributions to be tested
-from pymc_experimental.distributions import GenExtreme
+from pymc_experimental.distributions import Chi, GenExtreme
 
 
 class TestGenExtremeClass:
@@ -149,3 +150,26 @@ class TestGenExtreme(BaseTestDistributionRandom):
         "check_pymc_draws_match_reference",
         "check_rv_size",
     ]
+
+
+class TestChiClass:
+    """
+    Wrapper class so that tests of experimental additions can be dropped into
+    PyMC directly on adoption.
+    """
+
+    def test_logp(self):
+        check_logp(
+            Chi,
+            Rplus,
+            {"nu": Rplus},
+            lambda value, nu: sp.chi.logpdf(value, df=nu),
+        )
+
+    def test_logcdf(self):
+        check_logcdf(
+            Chi,
+            Rplus,
+            {"nu": Rplus},
+            lambda value, nu: sp.chi.logcdf(value, df=nu),
+        )

--- a/pymc_experimental/tests/distributions/test_continuous.py
+++ b/pymc_experimental/tests/distributions/test_continuous.py
@@ -11,13 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import platform
-
 import numpy as np
 import pymc as pm
 
 # general imports
-import pytensor
 import pytest
 import scipy.stats.distributions as sp
 
@@ -47,10 +44,6 @@ class TestGenExtremeClass:
     pm.logp(GenExtreme.dist(mu=0.,sigma=1.,xi=0.5),value=-0.01)
     """
 
-    @pytest.mark.xfail(
-        condition=(pytensor.config.floatX == "float32"),
-        reason="PyMC underflows earlier than scipy on float32",
-    )
     def test_logp(self):
         def ref_logp(value, mu, sigma, xi):
             if 1 + xi * (value - mu) / sigma > 0:
@@ -69,13 +62,6 @@ class TestGenExtremeClass:
             ref_logp,
         )
 
-        if pytensor.config.floatX == "float32":
-            raise Exception("Flaky test: It passed this time, but XPASS is not allowed.")
-
-    @pytest.mark.skipif(
-        (pytensor.config.floatX == "float32" and platform.system() == "Windows"),
-        reason="Scipy gives different results on Windows and does not match with desired accuracy",
-    )
     def test_logcdf(self):
         def ref_logcdf(value, mu, sigma, xi):
             if 1 + xi * (value - mu) / sigma > 0:

--- a/pymc_experimental/tests/distributions/test_multivariate.py
+++ b/pymc_experimental/tests/distributions/test_multivariate.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pymc as pm
-import pytensor
 import pytest
 
 import pymc_experimental as pmx
@@ -96,10 +95,6 @@ class TestR2D2M2CP:
             phi_args_base["importance_concentration"] = 10
         return phi_args_base
 
-    @pytest.mark.skipif(
-        pytensor.config.floatX == "float32",
-        reason="pytensor.config.floatX == 'float32', https://github.com/pymc-devs/pymc/issues/6779",
-    )
     def test_init(
         self,
         dims,


### PR DESCRIPTION
Following the discussion [here](https://github.com/pymc-devs/pymc/discussions/6905) and obsolete PRs [here](https://github.com/pymc-devs/pytensor/pull/440) and [here](https://github.com/pymc-devs/pymc/pull/6907), I have attempted to implement a Chi distribution helper class using `CustomDist`.

The distribution is functionally correct in that it is able to reproduce the `scipy` chi PDF.

There is an issue with adding this distribution to a `pymc` model, however. For example:

```python
import pymc as pm
from pymc_experimental.distributions import Chi
with pm.Model() as model:
    pm.Chi("x", df=1)
print(model.initial_point())
```
results in
```
TypeError: Cannot convert Type Scalar(float64, shape=()) (of Variable Exp.0) into Type Vector(float64, shape=(1,)). You can try to manually convert Exp.0 into a Vector(float64, shape=(1,)).
```
I can't quite narrow down this issue, so any help would be appreciated!