### PR TITLE
Fix imports from `gp.util`

### DIFF
--- a/pymc_experimental/statespace/filters/kalman_filter.py
+++ b/pymc_experimental/statespace/filters/kalman_filter.py
@@ -9,7 +9,6 @@ from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.nlinalg import matrix_dot
-from pytensor.tensor.slinalg import SolveTriangular
 
 from pymc_experimental.statespace.filters.utilities import (
     quad_form_sym,
@@ -22,7 +21,6 @@ from pymc_experimental.statespace.utils.pytensor_scipy import solve_discrete_are
 MVN_CONST = pt.log(2 * pt.constant(np.pi, dtype="float64"))
 PARAM_NAMES = ["c", "d", "T", "Z", "R", "H", "Q"]
 
-solve_lower_triangular = SolveTriangular(lower=True)
 assert_data_is_1d = Assert("UnivariateTimeSeries filter requires data be at most 1-dimensional")
 assert_time_varying_dim_correct = Assert(
     "The first dimension of a time varying matrix (the time dimension) must be "
@@ -684,13 +682,13 @@ class CholeskyFilter(BaseFilter):
         F_chol = pt.linalg.cholesky(F)
 
         # If everything is missing, K = 0, IKZ = I
-        K = solve_lower_triangular(F_chol.T, solve_lower_triangular(F_chol, PZT.T)).T
+        K = pt.linalg.solve_triangular(F_chol.T, pt.linalg.solve_triangular(F_chol, PZT.T)).T
         I_KZ = self.eye_states - K.dot(Z)
 
         a_filtered = a + K.dot(v)
         P_filtered = quad_form_sym(I_KZ, P) + quad_form_sym(K, H)
 
-        inner_term = solve_lower_triangular(F_chol.T, solve_lower_triangular(F_chol, v))
+        inner_term = pt.linalg.solve_triangular(F_chol.T, pt.linalg.solve_triangular(F_chol, v))
         n = y.shape[0]
 
         ll = pt.switch(

--- a/pymc_experimental/statespace/filters/kalman_filter.py
+++ b/pymc_experimental/statespace/filters/kalman_filter.py
@@ -9,6 +9,7 @@ from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.nlinalg import matrix_dot
+from pytensor.tensor.slinalg import solve_triangular
 
 from pymc_experimental.statespace.filters.utilities import (
     quad_form_sym,
@@ -682,13 +683,13 @@ class CholeskyFilter(BaseFilter):
         F_chol = pt.linalg.cholesky(F)
 
         # If everything is missing, K = 0, IKZ = I
-        K = pt.linalg.solve_triangular(F_chol.T, pt.linalg.solve_triangular(F_chol, PZT.T)).T
+        K = solve_triangular(F_chol.T, solve_triangular(F_chol, PZT.T)).T
         I_KZ = self.eye_states - K.dot(Z)
 
         a_filtered = a + K.dot(v)
         P_filtered = quad_form_sym(I_KZ, P) + quad_form_sym(K, H)
 
-        inner_term = pt.linalg.solve_triangular(F_chol.T, pt.linalg.solve_triangular(F_chol, v))
+        inner_term = solve_triangular(F_chol.T, solve_triangular(F_chol, v))
         n = y.shape[0]
 
         ll = pt.switch(


### PR DESCRIPTION
pymc-devs/pymc@ec64d40 breaks imports in the `latent-approx.py` module, this PR fixes it. Also does the same refactoring as that PR here, removing custom SolveTriangular Ops definitions with `pt.linalg.solve_triangular`