### PR TITLE
Set data when building Linearmodel

### DIFF
--- a/pymc_experimental/linearmodel.py
+++ b/pymc_experimental/linearmodel.py
@@ -67,8 +67,6 @@ class LinearModel(ModelBuilder):
         """
         cfg = self.model_config
 
-        # The model is built with placeholder data.
-        # Actual data will be set by _data_setter when fitting or evaluating the model.
         # Data array size can change but number of dimensions must stay the same.
         with pm.Model() as self.model:
             x = pm.MutableData("x", np.zeros((1,)), dims="observation")
@@ -93,6 +91,8 @@ class LinearModel(ModelBuilder):
                 observed=y_data,
                 dims="observation",
             )
+
+        self._data_setter(X, y)
 
     def _data_setter(self, X: pd.DataFrame, y: Optional[Union[pd.DataFrame, pd.Series]] = None):
         with self.model:

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -608,7 +608,7 @@ class ModelBuilder:
             self.set_idata_attrs(prior_pred)
             if extend_idata:
                 if self.idata is not None:
-                    self.idata.extend(prior_pred)
+                    self.idata.extend(prior_pred, join="right")
                 else:
                     self.idata = prior_pred
 

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -299,8 +299,8 @@ class ModelBuilder:
         with self.model:
             sampler_args = {**self.sampler_config, **kwargs}
             idata = pm.sample(**sampler_args)
-            idata.extend(pm.sample_prior_predictive())
-            idata.extend(pm.sample_posterior_predictive(idata))
+            idata.extend(pm.sample_prior_predictive(), join="right")
+            idata.extend(pm.sample_posterior_predictive(idata), join="right")
 
         idata = self.set_idata_attrs(idata)
         return idata
@@ -640,7 +640,7 @@ class ModelBuilder:
         with self.model:  # sample with new input data
             post_pred = pm.sample_posterior_predictive(self.idata, **kwargs)
             if extend_idata:
-                self.idata.extend(post_pred)
+                self.idata.extend(post_pred, join="right")
 
         posterior_predictive_samples = az.extract(
             post_pred, "posterior_predictive", combined=combined

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -601,17 +601,16 @@ class ModelBuilder:
 
         if self.model is None:
             self.build_model(X_pred, y_pred)
-
-        self._data_setter(X_pred, y_pred)
-        if self.model is not None:
-            with self.model:  # sample with new input data
-                prior_pred: az.InferenceData = pm.sample_prior_predictive(samples, **kwargs)
-                self.set_idata_attrs(prior_pred)
-                if extend_idata:
-                    if self.idata is not None:
-                        self.idata.extend(prior_pred)
-                    else:
-                        self.idata = prior_pred
+        else:
+            self._data_setter(X_pred, y_pred)
+        with self.model:  # sample with new input data
+            prior_pred: az.InferenceData = pm.sample_prior_predictive(samples, **kwargs)
+            self.set_idata_attrs(prior_pred)
+            if extend_idata:
+                if self.idata is not None:
+                    self.idata.extend(prior_pred)
+                else:
+                    self.idata = prior_pred
 
         prior_predictive_samples = az.extract(prior_pred, "prior_predictive", combined=combined)
 

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -595,7 +595,7 @@ class ModelBuilder:
             Prior predictive samples for each input X_pred
         """
         if y_pred is None:
-            y_pred = np.zeros(len(X_pred))
+            y_pred = pd.Series(np.zeros(len(X_pred)), name=self.output_var)
         if samples is None:
             samples = self.sampler_config.get("draws", 500)
 

--- a/pymc_experimental/tests/test_linearmodel.py
+++ b/pymc_experimental/tests/test_linearmodel.py
@@ -56,8 +56,8 @@ def toy_X():
 @pytest.fixture(scope="module")
 def toy_y(toy_X, toy_actual_params):
     y = toy_actual_params["slope"] * toy_X["input"] + toy_actual_params["intercept"]
-    np.random.seed(427)
-    y = y + np.random.normal(0, toy_actual_params["obs_error"], size=len(toy_X))
+    rng = np.random.default_rng(427)
+    y = y + rng.normal(0, toy_actual_params["obs_error"], size=len(toy_X))
     y = pd.Series(y, name="output")
     return y
 

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -220,6 +220,68 @@ def test_sample_posterior_predictive(fitted_model_instance, combined):
     assert np.issubdtype(pred[fitted_model_instance.output_var].dtype, np.floating)
 
 
+@pytest.mark.parametrize("extend_idata", [True, False])
+def test_sample_prior_extend_idata_param(fitted_model_instance, extend_idata):
+    output_var = fitted_model_instance.output_var
+    idata_prev = fitted_model_instance.idata.prior_predictive[output_var]
+
+    # Since coordinates are provided, the dimension must match
+    n_pred = 100  # Must match toy_x
+    x_pred = np.random.uniform(0, 1, n_pred)
+
+    prediction_data = pd.DataFrame({"input": x_pred})
+    pred = fitted_model_instance.sample_prior_predictive(
+        prediction_data["input"], combined=False, extend_idata=extend_idata
+    )
+
+    pred_unstacked = pred[output_var].values
+    idata_now = fitted_model_instance.idata.prior_predictive[output_var].values
+
+    if extend_idata:
+        # After sampling, data in the model should be the same as the predictions
+        np.testing.assert_array_equal(idata_now, pred_unstacked)
+        # Data in the model should NOT be the same as before
+        if idata_now.shape == idata_prev.values.shape:
+            assert np.sum(np.abs(idata_now - idata_prev.values) < 1e-5) <= 2
+    else:
+        # After sampling, data in the model should be the same as it was before
+        np.testing.assert_array_equal(idata_now, idata_prev.values)
+        # Data in the model should NOT be the same as the predictions
+        if idata_now.shape == pred_unstacked.shape:
+            assert np.sum(np.abs(idata_now - pred_unstacked) < 1e-5) <= 2
+
+
+@pytest.mark.parametrize("extend_idata", [True, False])
+def test_sample_posterior_extend_idata_param(fitted_model_instance, extend_idata):
+    output_var = fitted_model_instance.output_var
+    idata_prev = fitted_model_instance.idata.posterior_predictive[output_var]
+
+    # Since coordinates are provided, the dimension must match
+    n_pred = 100  # Must match toy_x
+    x_pred = np.random.uniform(0, 1, n_pred)
+
+    prediction_data = pd.DataFrame({"input": x_pred})
+    pred = fitted_model_instance.sample_posterior_predictive(
+        prediction_data["input"], combined=False, extend_idata=extend_idata
+    )
+
+    pred_unstacked = pred[output_var].values
+    idata_now = fitted_model_instance.idata.posterior_predictive[output_var].values
+
+    if extend_idata:
+        # After sampling, data in the model should be the same as the predictions
+        np.testing.assert_array_equal(idata_now, pred_unstacked)
+        # Data in the model should NOT be the same as before
+        if idata_now.shape == idata_prev.values.shape:
+            assert np.sum(np.abs(idata_now - idata_prev.values) < 1e-5) <= 2
+    else:
+        # After sampling, data in the model should be the same as it was before
+        np.testing.assert_array_equal(idata_now, idata_prev.values)
+        # Data in the model should NOT be the same as the predictions
+        if idata_now.shape == pred_unstacked.shape:
+            assert np.sum(np.abs(idata_now - pred_unstacked) < 1e-5) <= 2
+
+
 def test_model_config_formatting():
     model_config = {
         "a": {

--- a/pymc_experimental/tests/test_model_builder.py
+++ b/pymc_experimental/tests/test_model_builder.py
@@ -167,6 +167,9 @@ def test_save_input_params(fitted_model_instance):
     assert fitted_model_instance.idata.attrs["test_paramter"] == '"test_paramter"'
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Permissions for temp files not granted on windows CI."
+)
 def test_save_load(fitted_model_instance):
     temp = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
     fitted_model_instance.save(temp.name)
@@ -218,9 +221,6 @@ def test_fit_no_y(toy_X):
     assert "posterior" in model_builder.idata.groups()
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Permissions for temp files not granted on windows CI."
-)
 def test_predict(fitted_model_instance):
     x_pred = np.random.uniform(low=0, high=1, size=100)
     prediction_data = pd.DataFrame({"input": x_pred})


### PR DESCRIPTION
Fixes #248 

I also have a commit in here with some clean-up to `ModelBuilder.sample_prior_predictive` that I saw while working on this. It's unrelated but relatively minor.