### PR TITLE
Implement Maxwell Distribution

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -29,6 +29,7 @@ Distributions
    :toctree: generated/
 
    Chi
+   Maxwell
    DiscreteMarkovChain
    GeneralizedPoisson
    GenExtreme

--- a/pymc_experimental/distributions/__init__.py
+++ b/pymc_experimental/distributions/__init__.py
@@ -17,7 +17,7 @@
 Experimental probability distributions for stochastic nodes in PyMC.
 """
 
-from pymc_experimental.distributions.continuous import Chi, GenExtreme
+from pymc_experimental.distributions.continuous import Chi, GenExtreme, Maxwell
 from pymc_experimental.distributions.discrete import GeneralizedPoisson, Skellam
 from pymc_experimental.distributions.histogram_utils import histogram_approximation
 from pymc_experimental.distributions.multivariate import R2D2M2CP
@@ -30,4 +30,5 @@ __all__ = [
     "R2D2M2CP",
     "histogram_approximation",
     "Chi",
+    "Maxwell",
 ]

--- a/pymc_experimental/distributions/continuous.py
+++ b/pymc_experimental/distributions/continuous.py
@@ -28,6 +28,7 @@ from pymc.distributions import transforms
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import Continuous
 from pymc.distributions.shape_utils import rv_size_is_none
+from pymc.logprob.utils import CheckParameterValue
 from pymc.pytensorf import floatX
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
@@ -328,6 +329,8 @@ class Maxwell:
     def maxwell_dist(a: TensorVariable, size: TensorVariable) -> TensorVariable:
         if rv_size_is_none(size):
             size = a.shape
+
+        a = CheckParameterValue("a > 0")(a, pt.all(pt.gt(a, 0)))
 
         return Chi.dist(nu=3, size=size) * a
 

--- a/pymc_experimental/distributions/continuous.py
+++ b/pymc_experimental/distributions/continuous.py
@@ -326,6 +326,8 @@ class Maxwell:
 
     @staticmethod
     def maxwell_dist(a: TensorVariable, size: TensorVariable) -> TensorVariable:
+        if rv_size_is_none(size):
+            size = a.shape
         return Chi.dist(nu=3, size=size) * a
 
     def __new__(cls, name, a, **kwargs):

--- a/pymc_experimental/distributions/continuous.py
+++ b/pymc_experimental/distributions/continuous.py
@@ -328,6 +328,7 @@ class Maxwell:
     def maxwell_dist(a: TensorVariable, size: TensorVariable) -> TensorVariable:
         if rv_size_is_none(size):
             size = a.shape
+
         return Chi.dist(nu=3, size=size) * a
 
     def __new__(cls, name, a, **kwargs):

--- a/pymc_experimental/distributions/continuous.py
+++ b/pymc_experimental/distributions/continuous.py
@@ -328,50 +328,11 @@ class Maxwell:
     def maxwell_dist(a: TensorVariable, size: TensorVariable) -> TensorVariable:
         return Chi.dist(nu=3, size=size) * a
 
-    @staticmethod
-    def maxwell_logp(value, a):
-        res = (
-            pt.log(pt.sqrt(2.0 / pt.pi))
-            + 2 * pt.log(value)
-            - 3 * pt.log(a)
-            - pt.sqr(value) / (2 * pt.sqr(a))
-        )
-        res = pt.switch(
-            value > 0,
-            res,
-            -pt.inf,
-        )
-        return check_parameters(
-            res,
-            a > 0,
-            msg="a > 0",
-        )
-
-    @staticmethod
-    def maxwell_logcdf(value, a):
-        res = pt.erf(value / (pt.sqrt(2) * a)) - pt.sqrt(2.0 / pt.pi) * (value / a) * pt.exp(
-            -pt.sqr(value) / (2 * pt.sqr(a))
-        )
-        res = pt.log(res)
-
-        res = pt.switch(
-            value > 0,
-            res,
-            -pt.inf,
-        )
-        return check_parameters(
-            res,
-            a > 0,
-            msg="a > 0",
-        )
-
     def __new__(cls, name, a, **kwargs):
         return CustomDist(
             name,
             a,
             dist=cls.maxwell_dist,
-            logp=cls.maxwell_logp,
-            logcdf=cls.maxwell_logcdf,
             class_name="Maxwell",
             **kwargs,
         )
@@ -381,8 +342,6 @@ class Maxwell:
         return CustomDist.dist(
             a,
             dist=cls.maxwell_dist,
-            logp=cls.maxwell_logp,
-            logcdf=cls.maxwell_logcdf,
             class_name="Maxwell",
             **kwargs,
         )

--- a/pymc_experimental/tests/distributions/test_continuous.py
+++ b/pymc_experimental/tests/distributions/test_continuous.py
@@ -33,7 +33,7 @@ from pymc.testing import (
 )
 
 # the distributions to be tested
-from pymc_experimental.distributions import Chi, GenExtreme
+from pymc_experimental.distributions import Chi, GenExtreme, Maxwell
 
 
 class TestGenExtremeClass:
@@ -158,4 +158,27 @@ class TestChiClass:
             Rplus,
             {"nu": Rplus},
             lambda value, nu: sp.chi.logcdf(value, df=nu),
+        )
+
+
+class TestMaxwell:
+    """
+    Wrapper class so that tests of experimental additions can be dropped into
+    PyMC directly on adoption.
+    """
+
+    def test_logp(self):
+        check_logp(
+            Maxwell,
+            Rplus,
+            {"a": Rplus},
+            lambda value, a: sp.maxwell.logpdf(value, scale=a),
+        )
+
+    def test_logcdf(self):
+        check_logcdf(
+            Maxwell,
+            Rplus,
+            {"a": Rplus},
+            lambda value, a: sp.maxwell.logcdf(value, scale=a),
         )

--- a/pymc_experimental/tests/distributions/test_continuous.py
+++ b/pymc_experimental/tests/distributions/test_continuous.py
@@ -173,7 +173,6 @@ class TestMaxwell:
             Rplus,
             {"a": Rplus},
             lambda value, a: sp.maxwell.logpdf(value, scale=a),
-            skip_paramdomain_outside_edge_test=True,
         )
 
     def test_logcdf(self):
@@ -182,5 +181,4 @@ class TestMaxwell:
             Rplus,
             {"a": Rplus},
             lambda value, a: sp.maxwell.logcdf(value, scale=a),
-            skip_paramdomain_outside_edge_test=True,
         )

--- a/pymc_experimental/tests/distributions/test_continuous.py
+++ b/pymc_experimental/tests/distributions/test_continuous.py
@@ -173,6 +173,7 @@ class TestMaxwell:
             Rplus,
             {"a": Rplus},
             lambda value, a: sp.maxwell.logpdf(value, scale=a),
+            skip_paramdomain_outside_edge_test=True,
         )
 
     def test_logcdf(self):
@@ -181,4 +182,5 @@ class TestMaxwell:
             Rplus,
             {"a": Rplus},
             lambda value, a: sp.maxwell.logcdf(value, scale=a),
+            skip_paramdomain_outside_edge_test=True,
         )


### PR DESCRIPTION
Have the logp tests working like the other two distributions. I tried to implement the logcdf but am hitting some difficulties with those. The values are relatively close but are off by only a decimal in a few cases. I'm checking the translation from wikipedia formula and will look for some simplifications if possible. I see the scipy implements like [this](https://github.com/scipy/scipy/blob/f990b1d2471748c79bc4260baf8923db0a5248af/scipy/stats/_continuous_distns.py#L6299-L6300). If anything is obvious, let me know