### PR TITLE
add zerosum hierarchy

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -1,16 +1,17 @@
 name: pymc-experimental-test
 channels:
-- conda-forge
-- defaults
+  - conda-forge
+  - defaults
 dependencies:
-- pip
+  - pip
 
-- pytest-cov>=2.5
-- pytest>=3.0
-- dask
-- xhistogram
-- statsmodels
-- pip:
-  - pymc>=5.9.0  # CI was failing to resolve
-  - blackjax
-  - scikit-learn
+  - pytest-cov>=2.5
+  - pytest>=3.0
+  - dask
+  - xhistogram
+  - statsmodels
+  - formulae
+  - pip:
+      - pymc>=5.9.0 # CI was failing to resolve
+      - blackjax
+      - scikit-learn

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -1,15 +1,16 @@
 name: pymc-experimental-test
 channels:
-- conda-forge
-- defaults
+  - conda-forge
+  - defaults
 dependencies:
-- pip
-- pytest-cov>=2.5
-- pytest>=3.0
-- dask
-- xhistogram
-- statsmodels
-- pip:
-  - pymc>=5.9.0  # CI was failing to resolve
-  - blackjax
-  - scikit-learn
+  - pip
+  - pytest-cov>=2.5
+  - pytest>=3.0
+  - dask
+  - xhistogram
+  - statsmodels
+  - formulae
+  - pip:
+      - pymc>=5.9.0 # CI was failing to resolve
+      - blackjax
+      - scikit-learn

--- a/pymc_experimental/tests/utils/test_hierarchy.py
+++ b/pymc_experimental/tests/utils/test_hierarchy.py
@@ -1,0 +1,60 @@
+import pymc as pm
+import pytest
+
+from pymc_experimental.utils.hierarchy import zerosum_hierarchy
+
+
+@pytest.fixture(autouse=True)
+def model():
+    with pm.Model() as model:
+        yield model
+
+
+def test_hierarchy_init(model):
+    model.add_coords(dict(a=range(2), b=range(3)))
+    var = zerosum_hierarchy("z0 ~ a", ("a",))
+    assert "z0::_a" in model.named_vars
+    assert "z0::weight" not in model.named_vars
+    var = zerosum_hierarchy(
+        "z1 ~ a+b",
+        ("a", "b"),
+        importance=dict(a=3),
+    )
+    assert "z1::_a" in model.named_vars
+    assert "z1::_b" in model.named_vars
+    assert "z1::weight" in model.named_vars
+    var = zerosum_hierarchy("z2 ~ a*b", ("a", "b"))
+    assert "z2::_a" in model.named_vars
+    assert "z2::_b" in model.named_vars
+    assert "z2::_a_b" in model.named_vars
+    assert "z2::weight" in model.named_vars
+
+
+def test_zerosum_hierarchy_formula_not_simple():
+    with pytest.raises(ValueError, match="Formula should only have Variable terms"):
+        zerosum_hierarchy("z ~ a+f(b)", ("a", "b"))
+
+
+def test_zerosum_hierarchy_formula_group_terms():
+    with pytest.raises(ValueError, match="Formula should not have any group terms"):
+        zerosum_hierarchy("z ~ a:b + (1|b)", ("a", "b"))
+
+
+def test_zerosum_hierarchy_formula_no_response():
+    with pytest.raises(ValueError, match="Formula should have named Response"):
+        zerosum_hierarchy("a", ("a",))
+
+
+def test_zerosum_hierarchy_response_in_dims():
+    with pytest.raises(ValueError, match="Named Response should not be in dims"):
+        zerosum_hierarchy("a ~ b", ("a", "b"))
+
+
+def test_zerosum_non_empty():
+    with pytest.raises(ValueError, match="Formula should have at least one Term"):
+        zerosum_hierarchy("a ~ 1", ())
+
+
+def test_zerosum_hierarchy_formula_not_simple():
+    with pytest.raises(ValueError, match="There are unexpected importance keys: {'b'}"):
+        zerosum_hierarchy("z ~ a", ("a",), importance=dict(b=12.0))

--- a/pymc_experimental/tests/utils/test_pytensorf.py
+++ b/pymc_experimental/tests/utils/test_pytensorf.py
@@ -1,0 +1,46 @@
+import pytensor.tensor as pt
+import pytest
+
+from pymc_experimental.utils.pytensorf import (
+    named_shuffle_pattern,
+    shuffle_named_tensor,
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        [("time",), ("time", "group"), (0, "x")],
+        [("time", "group"), ("time",), ValueError],
+        [("time", "group"), ("group", "time"), (1, 0)],
+        [("time",), ("time", None), (0, "x")],
+        [(0,), (0, "group"), (0, "x")],
+    ],
+)
+def testnamed_shuffle_pattern(case):
+    inp, out, res = case
+    if not isinstance(res, tuple):
+        with pytest.raises(res):
+            named_shuffle_pattern(inp, out)
+    else:
+        assert named_shuffle_pattern(inp, out) == res
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        [("time",), ("time", "group"), (11, 4, 1)],
+        [("time", "group"), ("time",), ValueError],
+        [(), ("group",), (11, 1)],
+    ],
+)
+def test_shuffle_named_tensor(case):
+    inp, out, res = case
+    input_shape = (11, *(len(d) for d in inp))
+    tensor = pt.ones(input_shape)
+    if not isinstance(res, tuple):
+        with pytest.raises(res):
+            shuffle_named_tensor(tensor, inp, out)
+    else:
+        out_tensor = shuffle_named_tensor(tensor, inp, out).eval()
+        assert out_tensor.shape == res

--- a/pymc_experimental/utils/hierarchy.py
+++ b/pymc_experimental/utils/hierarchy.py
@@ -53,6 +53,17 @@ def zerosum_hierarchy(
     -------
     TensorVariable
         Resulting ZeroSum structured tensor with unit variance.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        with pm.Model(coords=dict(groups=range(10), stages=range(3))):
+            mean = pm.Normal("mu")
+            sigma = pm.Exponential("sigma")
+            z = zerosum_hierarchy("z ~ groups + stages", importance=dict(groups=10), named=False)
+            group_param = mean + z * sigma
     """
     formula = cast(formulae.terms.terms.Model, formulae.model_description(formula_string))
     if formula.group_terms:

--- a/pymc_experimental/utils/hierarchy.py
+++ b/pymc_experimental/utils/hierarchy.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Dict, List, Optional, Tuple, cast
 
 import formulae.terms
 import numpy as np
@@ -22,9 +22,9 @@ def is_simple_formula(formula: formulae.terms.terms.Model) -> bool:
 
 def zerosum_hierarchy(
     formula_string: str,
-    dims: tuple[str, ...],
+    dims: Tuple[str, ...],
     named: bool = True,
-    importance: dict[str, pt.TensorLike] | None = None,
+    importance: Optional[Dict[str, pt.TensorLike]] = None,
     default_importance: pt.TensorLike = 1.0,
 ) -> pt.TensorVariable:
     """Zero Sum Hierarchy.
@@ -67,8 +67,8 @@ def zerosum_hierarchy(
         raise ValueError("Named Response should not be in dims")
     if set(dims) != formula.var_names - {out_name}:
         raise ValueError("Dims should match set of formula Variables")
-    base_names: list[str] = []
-    interactions: list[tuple[str, ...]] = []
+    base_names: List[str] = []
+    interactions: List[Tuple[str, ...]] = []
     for term in formula.terms:
         if isinstance(term, formulae.terms.terms.Intercept):
             continue
@@ -82,8 +82,8 @@ def zerosum_hierarchy(
     if not interactions:
         raise ValueError("Formula should have at least one Term")
     with pm.Model(name=out_name) as model:
-        zed: list[pt.TensorVariable] = []
-        alphas: list[pt.TensorLike] = []
+        zed: List[pt.TensorVariable] = []
+        alphas: List[pt.TensorLike] = []
         for name, zs_dims in zip(base_names, interactions):
             lengths = pt.prod([model.dim_lengths[c] for c in zs_dims])
             z = pm.ZeroSumNormal(

--- a/pymc_experimental/utils/hierarchy.py
+++ b/pymc_experimental/utils/hierarchy.py
@@ -1,0 +1,117 @@
+from typing import cast
+
+import formulae.terms
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+
+from pymc_experimental.utils.pytensorf import shuffle_named_tensor
+
+
+def is_simple_formula(formula: formulae.terms.terms.Model) -> bool:
+    for t in formula.terms:
+        if isinstance(t, formulae.terms.terms.Intercept):
+            continue
+        if not isinstance(t, formulae.terms.terms.Term):
+            return False
+        for c in t.components:
+            if not isinstance(c, formulae.terms.variable.Variable):
+                return False
+    return True
+
+
+def zerosum_hierarchy(
+    formula_string: str,
+    dims: tuple[str, ...],
+    named: bool = True,
+    importance: dict[str, pt.TensorLike] | None = None,
+    default_importance: pt.TensorLike = 1.0,
+) -> pt.TensorVariable:
+    """Zero Sum Hierarchy.
+
+    Parameters
+    ----------
+    formula_string : str
+        Wilkinson Notation of interactions, passed to formulae.
+    dims : tuple[str, ...]
+        Expected dims pattern of the resulting tensor.
+    named : bool, optional
+        If True, the output is wrapped in Deterministic, by default True
+    importance : dict[str, TensorLike] | None, optional
+        Dict mapping terms to their importance, by default None. Examples:
+
+        * for term `a`, key is `a`
+        * for term `a:b`, key is `a_b`
+        * for term `a*b`, possible keys is `a`, `b`, `a_b`
+
+        Raises a ValueError if there were unexpected keys
+
+    default_importance : TensorLike, optional
+        If term importance is not provided, the default one is used, by default 1.0
+
+    Returns
+    -------
+    TensorVariable
+        Resulting ZeroSum structured tensor with unit variance.
+    """
+    formula = cast(formulae.terms.terms.Model, formulae.model_description(formula_string))
+    if formula.group_terms:
+        raise ValueError("Formula should not have any group terms")
+    if not is_simple_formula(formula):
+        raise ValueError("Formula should only have Variable terms")
+    if formula.response:
+        out_name = formula.response.term.name
+    else:
+        raise ValueError("Formula should have named Response")
+    if out_name in dims:
+        raise ValueError("Named Response should not be in dims")
+    if set(dims) != formula.var_names - {out_name}:
+        raise ValueError("Dims should match set of formula Variables")
+    base_names: list[str] = []
+    interactions: list[tuple[str, ...]] = []
+    for term in formula.terms:
+        if isinstance(term, formulae.terms.terms.Intercept):
+            continue
+        zs_dims = tuple(c.name for c in term.components)
+        interactions.append(zs_dims)
+        base_names.append("_".join(zs_dims))
+    importance = importance or {}
+    keys_diff = set(importance) - set(base_names)
+    if keys_diff:
+        raise ValueError(f"There are unexpected importance keys: {keys_diff}")
+    if not interactions:
+        raise ValueError("Formula should have at least one Term")
+    with pm.Model(name=out_name) as model:
+        zed: list[pt.TensorVariable] = []
+        alphas: list[pt.TensorLike] = []
+        for name, zs_dims in zip(base_names, interactions):
+            lengths = pt.prod([model.dim_lengths[c] for c in zs_dims])
+            z = pm.ZeroSumNormal(
+                f"_{name}",
+                (lengths / (lengths - 1)) ** 0.5,
+                n_zerosum_axes=len(zs_dims),
+                dims=zs_dims,
+            )
+            imp = importance.get(
+                "_".join(zs_dims),
+                default_importance,
+            )
+            zed.append(shuffle_named_tensor(z, zs_dims, dims))
+            alphas.append(imp)
+        weight_dim_name = model.name_for(f"{out_name}_coord")
+        model.add_coord(weight_dim_name, base_names)
+        if len(zed) > 1:
+            weights = (
+                pm.Dirichlet(
+                    "weight",
+                    alphas,
+                    dims=weight_dim_name,
+                )
+                ** 0.5
+            )
+        else:
+            weights = np.array([1.0])
+        z = pt.add(*[c * weights[i] for i, c in enumerate(zed)])
+    if named:
+        z = pm.Deterministic(out_name, z, dims=dims)
+    return z

--- a/pymc_experimental/utils/pytensorf.py
+++ b/pymc_experimental/utils/pytensorf.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Literal, Sequence, Tuple, Union
 
 import pytensor
 from pymc import SymbolicRandomVariable
@@ -61,8 +61,9 @@ def rvs_in_graph(vars: Sequence[Variable]) -> bool:
 
 
 def named_shuffle_pattern(
-    input_dims: tuple[int | str, ...], output_dims: tuple[int | str | None, ...]
-) -> tuple[int | str, ...]:
+    input_dims: Tuple[Union[int, str], ...],
+    output_dims: Tuple[Union[int, str, None], ...],
+) -> Tuple[Union[int, Literal["x"]], ...]:
     if not (set(output_dims) - {None}).issuperset(input_dims):
         raise ValueError(f"Can't arrange {input_dims} to {output_dims}")
     else:
@@ -73,8 +74,8 @@ def named_shuffle_pattern(
 
 def shuffle_named_tensor(
     tensor: TensorVariable,
-    input_dims: tuple[str, ...],
-    output_dims: tuple[str, ...],
+    input_dims: Tuple[str, ...],
+    output_dims: Tuple[str, ...],
 ) -> TensorVariable:
     """Shuffle tensor using annotated dims.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymc>=5.8.2
+formulae
 scikit-learn


### PR DESCRIPTION
## Usecases

```
a + b - hierarchy without interactions, a, b - zerosum
a*b - hierarchy with interactions, a, b - zerosum, a_b - interaction effect with zerosum

(1 | a) + b - ??? should it be even considered?
```

## API

```python
with pm.Model(coords=dict(groups=range(10), stages=range(3))):
    mean = pm.Normal("mu")
    sigma = pm.Exponential("sigma")
    z = zerosum_hierarchy("z ~ groups + stages", importance=dict(groups=10), named=False)
    group_param = mean + z * sigma
```