### PR TITLE
Variationally Informed Parameterization

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -60,3 +60,13 @@ Statespace Models
    statespace/core
    statespace/filters
    statespace/models
+
+
+Model Transforms
+================
+.. automodule:: pymc_experimental.model.transforms
+.. autosummary::
+   :toctree: generated/
+
+   autoreparam.vip_reparametrize
+   autoreparam.VIP

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -9,6 +9,7 @@ import scipy.special
 from pymc.model.fgraph import (
     ModelNamed,
     fgraph_from_model,
+    model_deterministic,
     model_free_rv,
     model_from_fgraph,
     model_named,
@@ -132,7 +133,7 @@ def vip_reparam_node(
     )
     vip_rep_.name = rv.name
 
-    vip_rep = model_named(vip_rep_, *dims)
+    vip_rep = model_deterministic(vip_rep_, *dims)
     return vip_rep, logit_lam_
 
 

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -38,8 +38,6 @@ class VIP:
     """
 
     _logit_lambda: Dict[str, pytensor.tensor.sharedvar.TensorSharedVariable]
-    _eps: pytensor.tensor.sharedvar.TensorSharedVariable
-    _round: pytensor.tensor.sharedvar.TensorSharedVariable
 
     @property
     def variational_parameters(self) -> List[pytensor.tensor.sharedvar.TensorSharedVariable]:
@@ -55,51 +53,59 @@ class VIP:
         """
         return list(self._logit_lambda.values())
 
-    @property
-    def eps(self) -> float:
-        r"Clipping :math:`\varepsilon`."
-        return self.get_eps()
+    def truncate_lambda(self, **kwargs: float):
+        r"""Truncate :math:`\lambda_k` with :math:`\varepsilon`.
 
-    @property
-    def round(self) -> bool:
-        r"Clipping mode."
-        return self.get_round()
+        .. math::
 
-    def set_eps(self, value: float):
-        r"""Set clip :math:`\varepsilon`.
+            \hat \lambda_k = \begin{cases}
+                0, \quad &\lambda_k \le \varepsilon\\
+                \lambda_k, \quad &\varepsilon \lt \lambda_k \lt 1-\varepsilon\\
+                1, \quad &\lambda_k \ge 1-\varepsilon\\
+            \end{cases}
+
+        Parameters
+        ----------
+        kwargs : Dict[str, float]
+            Variable to :math:`\varepsilon` mapping.
+            If :math:`\lambda` (or :math:`1-\lambda`) is not passing
+            the threshold of :math:`\varepsilon`, it will be clipped
+            to 1 or zero if rounding is turned on.
+        """
+        lambdas = self.get_lambda()
+        update = dict()
+        for var, eps in kwargs.items():
+            lam = lambdas[var]
+            update[var] = np.piecewise(
+                lam,
+                [lam < eps, lam > (1 - eps)],
+                [0, 1, lambda x: x],
+            )
+        self.set_lambda(**update)
+
+    def truncate_all_lambda(self, value: float):
+        r"""Truncate all :math:`\lambda_k` with :math:`\varepsilon`.
+
+        .. math::
+
+            \hat \lambda_k = \begin{cases}
+                0, \quad &\lambda_k \le \varepsilon\\
+                \lambda_k, \quad &\varepsilon \lt \lambda_k \lt 1-\varepsilon\\
+                1, \quad &\lambda_k \ge 1-\varepsilon\\
+            \end{cases}
+
+
 
         Parameters
         ----------
         value : float
-            if :math:`\lambda` (or :math:`1-\lambda`) is not passing
-            the threshold of :math:`\varepsilon`, it will be clipped
-            to 1 or zero if rounding is turned on.
-        """
-        self._eps.set_value(float(value))
-
-    def set_round(self, value: bool):
-        r"""Set rounding mode.
-
-        Parameters
-        ----------
-        value : bool
-            Enable clipping using :math:`\varepsilon`
-        """
-        self._round.set_value(bool(value))
-
-    def get_eps(self) -> float:
-        r"""Get :math:`\varepsilon`.
-
-        Returns
-        -------
-        float
             :math:`\varepsilon`
         """
-        return self._eps.get_value()
-
-    def get_round(self) -> bool:
-        """Get rounding mode."""
-        return self._round.get_value()
+        truncate = dict.fromkeys(
+            self._logit_lambda.keys(),
+            value,
+        )
+        self.truncate_lambda(**truncate)
 
     def get_lambda(self) -> Dict[str, np.ndarray]:
         r"""Get :math:`\lambda_k` that are currently used by the model.
@@ -163,22 +169,29 @@ def vip_reparam_node(
     name: str,
     dims: List[Variable],
     transform: Transform,
-    eps: ModelNamed,
-    round: ModelNamed,
 ) -> Tuple[ModelDeterministic, ModelNamed]:
     if not isinstance(node.op, RandomVariable):
         raise TypeError("Op should be RandomVariable type")
     size = node.inputs[1]
     if not isinstance(size, pt.TensorConstant):
-        raise ValueError("Size should be static for autoreparameterization.")
-    return _vip_reparam_node(
-        op,
-        node=node,
-        name=name,
-        dims=dims,
-        transform=transform,
-        eps=eps,
-        round=round,
+        raise ValueError("Size should be static for autoreparametrization.")
+    logit_lam_ = pytensor.shared(
+        np.zeros(size.data),
+        shape=size.data,
+        name=f"{name}::lam_logit__",
+    )
+    logit_lam = model_named(logit_lam_, *dims)
+    lam = pt.sigmoid(logit_lam)
+    return (
+        _vip_reparam_node(
+            op,
+            node=node,
+            name=name,
+            dims=dims,
+            transform=transform,
+            lam=lam,
+        ),
+        logit_lam,
     )
 
 
@@ -189,9 +202,8 @@ def _vip_reparam_node(
     name: str,
     dims: List[Variable],
     transform: Transform,
-    eps: ModelNamed,
-    round: ModelNamed,
-) -> Tuple[ModelDeterministic, ModelNamed]:
+    lam: pt.TensorVariable,
+) -> ModelDeterministic:
     raise NotImplementedError
 
 
@@ -202,42 +214,13 @@ def _(
     name: str,
     dims: List[Variable],
     transform: Transform,
-    eps: ModelNamed,
-    round: ModelNamed,
-) -> Tuple[ModelDeterministic, ModelNamed]:
+    lam: pt.TensorVariable,
+) -> ModelDeterministic:
     rng, size, _, loc, scale = node.inputs
-    logit_lam_ = pytensor.shared(
-        np.zeros(size.data),
-        shape=size.data,
-        name=f"{name}::lam_logit__",
-    )
-    logit_lam = model_named(logit_lam_, *dims)
-    lam = pt.sigmoid(logit_lam)
-    nc_cond = pt.and_(pt.lt(lam, eps), pt.eq(round, 1))
-    c_cond = pt.and_(pt.gt(lam, 1 - eps), pt.eq(round, 1))
-
-    vip_loc_rv = pt.switch(
-        nc_cond,
-        0,
-        pt.switch(
-            c_cond,
-            loc,
-            lam * loc,
-        ),
-    )
-    vip_scale_rv = pt.switch(
-        nc_cond,
-        1,
-        pt.switch(
-            c_cond,
-            scale,
-            scale**lam,
-        ),
-    )
 
     vip_rv_ = pm.Normal.dist(
-        vip_loc_rv,
-        vip_scale_rv,
+        lam * loc,
+        scale**lam,
         size=size,
         rng=rng,
     )
@@ -250,15 +233,12 @@ def _(
         *dims,
     )
 
-    vip_rep_ = pt.switch(
-        nc_cond,
-        loc + vip_rv * scale,
-        pt.switch(c_cond, vip_rv, loc + scale ** (1 - lam) * (vip_rv - lam * loc)),
-    )
+    vip_rep_ = loc + scale ** (1 - lam) * (vip_rv - lam * loc)
+
     vip_rep_.name = name
 
     vip_rep = model_deterministic(vip_rep_, *dims)
-    return vip_rep, logit_lam
+    return vip_rep
 
 
 def vip_reparametrize(
@@ -364,8 +344,7 @@ def vip_reparametrize(
 
     .. code-block:: python
 
-        vip.set_eps(0.1)
-        vip.set_round(True)
+        vip.truncate_all_lambda(0.1)
 
     Sampling has to be performed again
 
@@ -374,17 +353,9 @@ def vip_reparametrize(
         with Reparam_eight:
             trace = pm.sample()
     """
-    if "_vip::eps" in model.named_vars:
-        raise ValueError(
-            "The model seems to be already auto-reparametrized. This action is done once."
-        )
     fmodel, memo = fgraph_from_model(model)
     lambda_names = []
     replacements = []
-    eps_ = pytensor.shared(np.array(1e-2, dtype=float), name="_vip::eps")
-    eps = model_named(eps_)
-    round_ = pytensor.shared(np.array(False, dtype=bool), name="_vip::round")
-    round = model_named(round_)
     for name in var_names:
         old = memo[model.named_vars[name]]
         rv, _, *dims = old.owner.inputs
@@ -394,13 +365,11 @@ def vip_reparametrize(
             name=rv.name,
             dims=dims,
             transform=old.owner.op.transform,
-            eps=eps,
-            round=round,
         )
         replacements.append((old, new))
         lambda_names.append(lam.name)
     toposort_replace(fmodel, replacements, reverse=True)
     reparam_model = model_from_fgraph(fmodel)
     model_lambdas = {n: reparam_model[l] for l, n in zip(lambda_names, var_names)}
-    vip = VIP(model_lambdas, reparam_model[eps.name], reparam_model[round.name])
+    vip = VIP(model_lambdas)
     return reparam_model, vip

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pymc as pm
@@ -168,7 +168,7 @@ def vip_reparam_node(
     node: Apply,
     name: str,
     dims: List[Variable],
-    transform: Transform,
+    transform: Optional[Transform],
 ) -> Tuple[ModelDeterministic, ModelNamed]:
     if not isinstance(node.op, RandomVariable):
         raise TypeError("Op should be RandomVariable type")
@@ -201,7 +201,7 @@ def _vip_reparam_node(
     node: Apply,
     name: str,
     dims: List[Variable],
-    transform: Transform,
+    transform: Optional[Transform],
     lam: pt.TensorVariable,
 ) -> ModelDeterministic:
     raise NotImplementedError
@@ -213,7 +213,7 @@ def _(
     node: Apply,
     name: str,
     dims: List[Variable],
-    transform: Transform,
+    transform: Optional[Transform],
     lam: pt.TensorVariable,
 ) -> ModelDeterministic:
     rng, size, _, loc, scale = node.inputs
@@ -230,7 +230,7 @@ def _(
     vip_rv = model_free_rv(
         vip_rv_,
         vip_rv_.clone(),
-        transform,
+        None,
         *dims,
     )
 

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -46,7 +46,7 @@ class VIP:
             logit_lam = scipy.special.logit(value)
             shared = self._logit_lambda[key]
             fill = np.full(
-                shared.get_value(True).shape,
+                shared.type.shape,
                 logit_lam,
             )
             shared.set_value(fill)
@@ -55,7 +55,7 @@ class VIP:
         logit_lam = scipy.special.logit(value)
         for shared in self._logit_lambda.values():
             fill = np.full(
-                shared.get_value(True).shape,
+                shared.type.shape,
                 logit_lam,
             )
             shared.set_value(fill)

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -218,7 +218,7 @@ def _(
 ) -> ModelDeterministic:
     rng, size, _, loc, scale = node.inputs
     if transform is not None:
-        raise NotImplementedError("Reparametrization with Transform is not implemented")
+        raise NotImplementedError("Reparametrization of Normal with Transform is not implemented")
     vip_rv_ = pm.Normal.dist(
         lam * loc,
         scale**lam,

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -156,7 +156,7 @@ def vip_reparametrize(
         new, lam = vip_reparam_node(old.owner, eps=eps, round=round)
         replacements.append((old, new))
         lambda_names.append(lam.name)
-    toposort_replace(fmodel, replacements)
+    toposort_replace(fmodel, replacements, reverse=True)
     reparam_model = model_from_fgraph(fmodel)
     model_lambdas = {n: reparam_model[l] for l, n in zip(lambda_names, var_names)}
     vip = VIP(model_lambdas, reparam_model[eps.name], reparam_model[round.name])

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -217,7 +217,8 @@ def _(
     lam: pt.TensorVariable,
 ) -> ModelDeterministic:
     rng, size, _, loc, scale = node.inputs
-
+    if transform is not None:
+        raise NotImplementedError("Reparametrization with Transform is not implemented")
     vip_rv_ = pm.Normal.dist(
         lam * loc,
         scale**lam,

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -139,7 +139,7 @@ class VIP:
         )
         self.set_lambda(**config)
 
-    def fit(self, *args, **kwargs) -> pm.MeanField:
+    def fit(self, *args, **kwargs) -> pm.Approximation:
         r"""Set :math:`\lambda_k` using Variational Inference.
 
         Examples

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Sequence, Tuple
 
 import numpy as np
 import pymc as pm
@@ -74,7 +74,7 @@ def vip_reparam_node(
     node: Apply,
     eps: ModelNamed,
     round: ModelNamed,
-) -> tuple[ModelNamed, pytensor.tensor.sharedvar.TensorSharedVariable]:
+) -> Tuple[ModelNamed, pytensor.tensor.sharedvar.TensorSharedVariable]:
     rv, _, *dims = node.inputs
     rng, size, _, loc, scale = rv.owner.inputs
     if not isinstance(size, pt.TensorConstant):
@@ -138,8 +138,8 @@ def vip_reparam_node(
 
 def vip_reparametrize(
     model: pm.Model,
-    var_names: list[str],
-) -> tuple[pm.Model, VIP]:
+    var_names: Sequence[str],
+) -> Tuple[pm.Model, VIP]:
     if "_vip::eps" in model.named_vars:
         raise ValueError(
             "The model seems to be already auto-reparametrized. This action is done once."
@@ -158,6 +158,6 @@ def vip_reparametrize(
         lambda_names.append(lam.name)
     toposort_replace(fmodel, replacements)
     reparam_model = model_from_fgraph(fmodel)
-    model_lambdas = {n: reparam_model[n] for n in lambda_names}
+    model_lambdas = {n: reparam_model[l] for l, n in zip(lambda_names, var_names)}
     vip = VIP(model_lambdas, reparam_model[eps.name], reparam_model[round.name])
     return reparam_model, vip

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -38,7 +38,7 @@ def test_random_draw(model_c: pm.Model, model_nc):
     model_c = pm.do(model_c, {"m": 3, "s": 2})
     model_nc = pm.do(model_nc, {"m": 3, "s": 2})
     model_v, vip = vip_reparametrize(model_c, ["g"])
-    assert "g" in model_v.deterministics
+    assert "g" in [v.name for v in model_v.deterministics]
     c = pm.draw(model_c["g"], random_seed=42, draws=1000)
     nc = pm.draw(model_nc["g"], random_seed=42, draws=1000)
     vip.set_all_lambda(1)
@@ -80,4 +80,4 @@ def test_multilevel():
     assert "a_g" in vip.get_lambda()
     assert "a_ig" in vip.get_lambda()
     assert {v.name for v in model_r.free_RVs} == {"a", "s", "a_g::tau_", "s_g", "a_ig::tau_"}
-    assert "a_g" in model_r.deterministics
+    assert "a_g" in [v.name for v in model_r.deterministics]

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -1,17 +1,58 @@
+import numpy as np
 import pymc as pm
+import pytest
 
 from pymc_experimental.model.transforms.autoreparam import vip_reparametrize
 
 
-def test_reparametrize_created():
-    with pm.Model() as model:
+@pytest.fixture
+def model_c():
+    with pm.Model() as mod:
         m = pm.Normal("m")
         s = pm.LogNormal("s")
-        g = pm.Normal("g", m, s, shape=5)
+        pm.Normal("g", m, s, shape=5)
+    return mod
 
-    model_reparam, vip = vip_reparametrize(model, ["g"])
+
+@pytest.fixture
+def model_nc():
+    with pm.Model() as mod:
+        m = pm.Normal("m")
+        s = pm.LogNormal("s")
+        pm.Deterministic("g", pm.Normal("z", shape=5) * s + m)
+    return mod
+
+
+def test_reparametrize_created(model_c: pm.Model):
+    model_reparam, vip = vip_reparametrize(model_c, ["g"])
     assert "g" in vip.get_lambda()
     assert "_vip::eps" in model_reparam.named_vars
     assert "_vip::round" in model_reparam.named_vars
     assert "g::lam_logit__" in model_reparam.named_vars
     assert "g::tau_" in model_reparam.named_vars
+    vip.set_all_lambda(1)
+    assert ~np.isfinite(model_reparam["g::lam_logit__"].get_value()).any()
+
+
+def test_random_draw(model_c: pm.Model, model_nc):
+    model_c = pm.do(model_c, {"m": 3, "s": 2})
+    model_nc = pm.do(model_nc, {"m": 3, "s": 2})
+    model_v, vip = vip_reparametrize(model_c, ["g"])
+
+    c = pm.draw(model_c["g"], random_seed=42, draws=1000)
+    nc = pm.draw(model_nc["g"], random_seed=42, draws=1000)
+    vip.set_all_lambda(1)
+    v_1 = pm.draw(model_v["g"], random_seed=42, draws=1000)
+    vip.set_all_lambda(0)
+    v_0 = pm.draw(model_v["g"], random_seed=42, draws=1000)
+    vip.set_all_lambda(0.5)
+    v_05 = pm.draw(model_v["g"], random_seed=42, draws=1000)
+    np.testing.assert_allclose(c.mean(), nc.mean())
+    np.testing.assert_allclose(c.mean(), v_0.mean())
+    np.testing.assert_allclose(v_05.mean(), v_1.mean())
+    np.testing.assert_allclose(v_1.mean(), nc.mean())
+
+    np.testing.assert_allclose(c.std(), nc.std())
+    np.testing.assert_allclose(c.std(), v_0.std())
+    np.testing.assert_allclose(v_05.std(), v_1.std())
+    np.testing.assert_allclose(v_1.std(), nc.std())

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -1,0 +1,17 @@
+import pymc as pm
+
+from pymc_experimental.model.transforms.autoreparam import vip_reparametrize
+
+
+def test_reparametrize_created():
+    with pm.Model() as model:
+        m = pm.Normal("m")
+        s = pm.LogNormal("s")
+        g = pm.Normal("g", m, s, shape=5)
+
+    model_reparam, vip = vip_reparametrize(model, ["g"])
+    assert "g" in vip.get_lambda()
+    assert "_vip::eps" in model_reparam.named_vars
+    assert "_vip::round" in model_reparam.named_vars
+    assert "g::lam_logit__" in model_reparam.named_vars
+    assert "g::tau_" in model_reparam.named_vars

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -38,7 +38,7 @@ def test_random_draw(model_c: pm.Model, model_nc):
     model_c = pm.do(model_c, {"m": 3, "s": 2})
     model_nc = pm.do(model_nc, {"m": 3, "s": 2})
     model_v, vip = vip_reparametrize(model_c, ["g"])
-
+    assert "g" in model_v.deterministics
     c = pm.draw(model_c["g"], random_seed=42, draws=1000)
     nc = pm.draw(model_nc["g"], random_seed=42, draws=1000)
     vip.set_all_lambda(1)
@@ -80,3 +80,4 @@ def test_multilevel():
     assert "a_g" in vip.get_lambda()
     assert "a_ig" in vip.get_lambda()
     assert {v.name for v in model_r.free_RVs} == {"a", "s", "a_g::tau_", "s_g", "a_ig::tau_"}
+    assert "a_g" in model_r.deterministics

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -56,3 +56,10 @@ def test_random_draw(model_c: pm.Model, model_nc):
     np.testing.assert_allclose(c.std(), v_0.std())
     np.testing.assert_allclose(v_05.std(), v_1.std())
     np.testing.assert_allclose(v_1.std(), nc.std())
+
+
+def test_reparam_fit(model_c):
+    model_v, vip = vip_reparametrize(model_c, ["g"])
+    with model_v:
+        vip.fit(random_seed=42)
+    np.testing.assert_allclose(vip.get_lambda()["g"], 0, atol=0.01)

--- a/pymc_experimental/tests/model/transforms/test_autoreparam.py
+++ b/pymc_experimental/tests/model/transforms/test_autoreparam.py
@@ -81,7 +81,7 @@ def test_multilevel():
     assert "a_g" in [v.name for v in model_r.deterministics]
 
 
-def test_set_truncate(model_c):
+def test_set_truncate(model_c: pm.Model):
     model_v, vip = vip_reparametrize(model_c, ["m", "g"])
     vip.set_all_lambda(0.93)
     np.testing.assert_allclose(vip.get_lambda()["g"], 0.93)

--- a/pymc_experimental/utils/autoreparam.py
+++ b/pymc_experimental/utils/autoreparam.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+from pymc.model.fgraph import (
+    ModelNamed,
+    fgraph_from_model,
+    model_free_rv,
+    model_from_fgraph,
+    model_named,
+)
+from pymc.pytensorf import toposort_replace
+from pytensor.graph.basic import Apply
+
+
+@dataclass
+class VIP:
+    lambda_: list[pytensor.tensor.sharedvar.TensorSharedVariable]
+    eps: pytensor.tensor.sharedvar.TensorSharedVariable
+    round: pytensor.tensor.sharedvar.TensorSharedVariable
+
+    def set_eps(self, value: float):
+        self.eps.set_value(float(value))
+
+    def set_round(self, value: bool):
+        self.round.set_value(bool(value))
+
+    def get_eps(self):
+        return self.eps.get_value()
+
+    def get_round(self):
+        return self.round.get_value()
+
+
+def vip_reparam_node(
+    node: Apply,
+    eps: ModelNamed,
+    round: ModelNamed,
+) -> tuple[ModelNamed, pytensor.tensor.sharedvar.TensorSharedVariable]:
+    rv, _, *dims = node.inputs
+    rng, size, _, loc, scale = rv.owner.inputs
+    if not isinstance(size, pt.TensorConstant):
+        raise ValueError("Size should be static for autoreparameterization.")
+    if not isinstance(rv.owner.op, pm.Normal):
+        raise ValueError("RV should be follow a Normal distribution.")
+    logit_lam_ = pytensor.shared(
+        np.zeros(size.data),
+        shape=size.data,
+        name=f"{rv.name}::lam_logit__",
+    )
+    logit_lam = model_named(logit_lam_, *dims)
+    lam = pt.sigmoid(logit_lam)
+    nc_cond = pt.and_(pt.lt(lam, eps), pt.eq(round, 1))
+    c_cond = pt.and_(pt.gt(lam, 1 - eps), pt.eq(round, 1))
+
+    vip_loc_rv = pt.switch(
+        nc_cond,
+        0,
+        pt.switch(
+            c_cond,
+            loc,
+            lam * loc,
+        ),
+    )
+    vip_scale_rv = pt.switch(
+        nc_cond,
+        1,
+        pt.switch(
+            c_cond,
+            scale,
+            scale**lam,
+        ),
+    )
+
+    vip_rv_ = pm.Normal.dist(
+        vip_loc_rv,
+        vip_scale_rv,
+        size=size,
+        rng=rng,
+    )
+    vip_rv_.name = f"{rv.name}::tau_"
+
+    vip_rv = model_free_rv(
+        vip_rv_,
+        vip_rv_.clone(),
+        node.op.transform,
+        *dims,
+    )
+
+    vip_rep_ = pt.switch(
+        nc_cond,
+        loc + vip_rv * scale,
+        pt.switch(c_cond, vip_rv, loc + scale ** (1 - lam) * (vip_rv - lam * loc)),
+    )
+    vip_rep_.name = rv.name
+
+    vip_rep = model_named(vip_rep_, *dims)
+    return vip_rep, logit_lam_
+
+
+def vip_reparametrize(
+    model: pm.Model,
+    var_names: list[str],
+) -> tuple[pm.Model, VIP]:
+    if "_vip::eps" in model.named_vars:
+        raise ValueError(
+            "The model seems to be already auto-reparametrized. This action is done once."
+        )
+    fmodel, memo = fgraph_from_model(model)
+    lambda_list = []
+    replacements = []
+    eps_ = pytensor.shared(np.array(1e-2, dtype=float), name="_vip::eps")
+    eps = model_named(eps_)
+    round_ = pytensor.shared(np.array(False, dtype=bool), name="_vip::round")
+    round = model_named(round_)
+    for name in var_names:
+        old = memo[model.named_vars[name]]
+        new, lam = vip_reparam_node(old.owner, eps=eps, round=round)
+        replacements.append((old, new))
+        lambda_list.append(lam)
+    toposort_replace(fmodel, replacements)
+    return model_from_fgraph(fmodel), VIP(lambda_list, eps_, round_)


### PR DESCRIPTION
This PR adds a tool to autoparameterize your model in the following way: https://arxiv.org/abs/1906.03028


![image](https://github.com/pymc-devs/pymc-experimental/assets/11705326/d97f2277-9905-47b9-a129-5dd0633b2b2b)


The intended api is like this

You need to convert tour model to change its structure

<img width="959" alt="image" src="https://github.com/pymc-devs/pymc-experimental/assets/11705326/959c3407-35e3-4b2e-9494-6f66485fc2c7">

Then you use your samplers

<img width="963" alt="image" src="https://github.com/pymc-devs/pymc-experimental/assets/11705326/1cec5942-965b-45b7-8472-384141ac683f">

For stability, you might want to turn on clipping for lambdas

<img width="925" alt="image" src="https://github.com/pymc-devs/pymc-experimental/assets/11705326/f4d88e0f-8432-4108-bbef-ea2dd385096f">
