### PR TITLE
Implement utility to recover marginalized variables from `MarginalModel`

### DIFF
--- a/pymc_experimental/model/marginal_model.py
+++ b/pymc_experimental/model/marginal_model.py
@@ -419,6 +419,9 @@ class MarginalModel(Model):
             joint_logps_norm = log_softmax(joint_logps, axis=0)
             if return_samples:
                 sample_rv_outs = pymc.Categorical.dist(logit_p=joint_logps)
+                if isinstance(rv.owner.op, DiscreteUniform):
+                    sample_rv_outs += rv_domain[0]
+
                 rv_loglike_fn = compile_pymc(
                     inputs=other_values,
                     outputs=[joint_logps_norm, sample_rv_outs],

--- a/pymc_experimental/model/marginal_model.py
+++ b/pymc_experimental/model/marginal_model.py
@@ -426,7 +426,7 @@ class MarginalModel(Model):
             joint_logps = pt.moveaxis(joint_logps, 0, -1)
 
             rv_loglike_fn = None
-            joint_logps_norm = log_softmax(joint_logps, axis=0)
+            joint_logps_norm = log_softmax(joint_logps, axis=-1)
             if return_samples:
                 sample_rv_outs = pymc.Categorical.dist(logit_p=joint_logps)
                 if isinstance(rv.owner.op, DiscreteUniform):

--- a/pymc_experimental/model/marginal_model.py
+++ b/pymc_experimental/model/marginal_model.py
@@ -234,7 +234,8 @@ class MarginalModel(Model):
         return m
 
     def marginalize(
-        self, rvs_to_marginalize: Union[TensorVariable, str, Sequence[TensorVariable], Sequence[str]]
+        self,
+        rvs_to_marginalize: Union[TensorVariable, str, Sequence[TensorVariable], Sequence[str]],
     ):
         if not isinstance(rvs_to_marginalize, Sequence):
             rvs_to_marginalize = (rvs_to_marginalize,)

--- a/pymc_experimental/tests/model/test_marginal_model.py
+++ b/pymc_experimental/tests/model/test_marginal_model.py
@@ -311,6 +311,7 @@ def test_recover_marginals_basic():
         true_logp(post.y.values.flatten(), post.sigma.values.flatten()),
         post.lp_k[0].values,
     )
+    np.testing.assert_almost_equal(logsumexp(post.lp_k, axis=-1), 0)
 
 
 def test_recover_marginals_coords():
@@ -418,6 +419,8 @@ def test_nested_recover_marginals():
         true_sub_idx_logp(post.y.values.flatten()),
         post.lp_sub_idx[0].values,
     )
+    np.testing.assert_almost_equal(logsumexp(post.lp_idx, axis=-1), 0)
+    np.testing.assert_almost_equal(logsumexp(post.lp_sub_idx, axis=-1), 0)
 
 
 @pytest.mark.filterwarnings("error")


### PR DESCRIPTION
This is a PR to add support for the `recover_marginals` method. This allows us to sample values and get access to the logps of discrete variables which we marginalized out during sampling.

Closes #286