### PR TITLE
Statespace: Don't automatically save statespace matrices as `Deterministic` variables

### DIFF
--- a/pymc_experimental/statespace/core/representation.py
+++ b/pymc_experimental/statespace/core/representation.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Type, Union
+from typing import Optional, Type, Union
 
 import numpy as np
 import pytensor
@@ -10,7 +10,7 @@ from pymc_experimental.statespace.utils.constants import (
 )
 
 floatX = pytensor.config.floatX
-KeyLike = Union[Tuple[Union[str, int]], str]
+KeyLike = Union[tuple[Union[str, int]], str]
 
 
 class PytensorRepresentation:
@@ -228,8 +228,8 @@ class PytensorRepresentation:
         self.shapes[key] = shape
 
     def _add_time_dim_to_slice(
-        self, name: str, slice_: Union[List[int], Tuple[int]], n_dim: int
-    ) -> Tuple[int]:
+        self, name: str, slice_: Union[list[int], tuple[int]], n_dim: int
+    ) -> tuple[int]:
         # Case 1: There is never a time dim. No changes needed.
         if name in NEVER_TIME_VARYING:
             return slice_

--- a/pymc_experimental/statespace/filters/kalman_filter.py
+++ b/pymc_experimental/statespace/filters/kalman_filter.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import pytensor
@@ -49,11 +49,11 @@ class BaseFilter(ABC):
         mode : str or None
             The mode used for Pytensor compilation.
 
-        seq_names : List[str]
+        seq_names : list[str]
             A list of name representing time-varying statespace matrices. That is, inputs that will need to be
             provided to the `sequences` argument of `pytensor.scan`
 
-        non_seq_names : List[str]
+        non_seq_names : list[str]
             A list of names representing static statespace matrices. That is, inputs that will need to be provided
             to the `non_sequences` argument of `pytensor.scan`
 
@@ -68,8 +68,8 @@ class BaseFilter(ABC):
         """
 
         self.mode: str = mode
-        self.seq_names: List[str] = []
-        self.non_seq_names: List[str] = []
+        self.seq_names: list[str] = []
+        self.non_seq_names: list[str] = []
 
         self.n_states = None
         self.n_posdef = None
@@ -121,8 +121,8 @@ class BaseFilter(ABC):
 
     @staticmethod
     def add_check_on_time_varying_shapes(
-        data: TensorVariable, sequence_params: List[TensorVariable]
-    ) -> List[Variable]:
+        data: TensorVariable, sequence_params: list[TensorVariable]
+    ) -> list[Variable]:
         """
         Insert a check that time-varying matrices match the data shape to the computational graph.
 
@@ -134,12 +134,12 @@ class BaseFilter(ABC):
         data : TensorVariable
             The tensor representing the data.
 
-        sequence_params : List[TensorVariable]
+        sequence_params : list[TensorVariable]
             A list of tensors to be provided to `pytensor.scan` as `sequences`.
 
         Returns
         -------
-        List[TensorVariable]
+        list[TensorVariable]
             A list of tensors wrapped in an `Assert` `Op` that checks the shape of the 0th dimension on each is equal
              to the shape of the 0th dimension on the data.
 
@@ -153,7 +153,7 @@ class BaseFilter(ABC):
 
         return params_with_assert
 
-    def unpack_args(self, args) -> Tuple:
+    def unpack_args(self, args) -> tuple:
         """
         The order of inputs to the inner scan function is not known, since some, all, or none of the input matrices
         can be time varying. The order arguments are fed to the inner function is sequences, outputs_info,
@@ -203,7 +203,7 @@ class BaseFilter(ABC):
         return_updates=False,
         missing_fill_value=None,
         cov_jitter=None,
-    ) -> List[TensorVariable]:
+    ) -> list[TensorVariable]:
         """
         Construct the computation graph for the Kalman filter. See [1] for details.
 
@@ -278,7 +278,7 @@ class BaseFilter(ABC):
             return filter_results, updates
         return filter_results
 
-    def _postprocess_scan_results(self, results, a0, P0, n) -> List[TensorVariable]:
+    def _postprocess_scan_results(self, results, a0, P0, n) -> list[TensorVariable]:
         """
         Transform the values returned by the Kalman Filter scan into a form expected by users. In particular:
         1. Append the initial state and covariance matrix to their respective Kalman predictions. This matches the
@@ -350,7 +350,7 @@ class BaseFilter(ABC):
 
     def handle_missing_values(
         self, y, Z, H
-    ) -> Tuple[TensorVariable, TensorVariable, TensorVariable, float]:
+    ) -> tuple[TensorVariable, TensorVariable, TensorVariable, float]:
         """
         This function handles missing values in the observation data `y` and adjusts the design matrix `Z` and the
         observation noise covariance matrix `H` accordingly. Missing values are replaced with zeros to prevent
@@ -398,7 +398,7 @@ class BaseFilter(ABC):
         return y_masked, Z_masked, H_masked, all_nan_flag
 
     @staticmethod
-    def predict(a, P, c, T, R, Q) -> Tuple[TensorVariable, TensorVariable]:
+    def predict(a, P, c, T, R, Q) -> tuple[TensorVariable, TensorVariable]:
         """
         Perform the prediction step of the Kalman filter.
 
@@ -450,7 +450,7 @@ class BaseFilter(ABC):
     @staticmethod
     def update(
         a, P, y, c, d, Z, H, all_nan_flag
-    ) -> Tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]:
+    ) -> tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]:
         """
         Perform the update step of the Kalman filter.
 
@@ -489,13 +489,13 @@ class BaseFilter(ABC):
 
         Returns
         -------
-        Tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]
+        tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]
             A tuple containing the updated state vector `a_filtered`, the updated covariance matrix `P_filtered`, the
             predicted observation `obs_mu`, the predicted observation covariance matrix `obs_cov`, and the log-likelihood `ll`.
         """
         raise NotImplementedError
 
-    def kalman_step(self, *args) -> Tuple:
+    def kalman_step(self, *args) -> tuple:
         """
         Performs a single iteration of the Kalman filter, which is composed of two steps : an update step and a
         prediction step. The timing convention follows [1], in which initial state and covariance estimates a0 and P0
@@ -624,7 +624,7 @@ class StandardFilter(BaseFilter):
 
         Returns
         -------
-        Tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, float]
+        tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, float]
             A tuple containing the updated state vector `a_filtered`, the updated covariance matrix `P_filtered`,
             the one-step forecast mean `y_hat`, one-step forcast covariance matrix  `F`, and the log-likelihood of
             the data, given the one-step forecasts, `ll`.
@@ -769,7 +769,7 @@ class SteadyStateFilter(BaseFilter):
         return_updates=False,
         missing_fill_value=None,
         cov_jitter=None,
-    ) -> List[TensorVariable]:
+    ) -> list[TensorVariable]:
         """
         Need to override the base step to add an argument to self.update, passing F_inv at every step.
         """

--- a/pymc_experimental/statespace/filters/kalman_smoother.py
+++ b/pymc_experimental/statespace/filters/kalman_smoother.py
@@ -100,6 +100,9 @@ class KalmanSmoother:
             [smoothed_covariances[::-1], pt.expand_dims(P_last, axis=(0,))], axis=0
         )
 
+        smoothed_states.name = "smoothed_states"
+        smoothed_covariances.name = "smoothed_covariances"
+
         return smoothed_states, smoothed_covariances
 
     def smoother_step(self, *args):

--- a/pymc_experimental/statespace/models/VARMAX.py
+++ b/pymc_experimental/statespace/models/VARMAX.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 import numpy as np
 import pytensor
@@ -31,7 +31,7 @@ class BayesianVARMAX(PyMCStateSpace):
         Number of autoregressive (AR) and moving average (MA) terms to include in the model. All terms up to the
         specified order are included. For restricted models, set zeros directly on the priors.
 
-    endog_names: List of str, optional
+    endog_names: list of str, optional
         Names of the endogenous variables being modeled. Used to generate names for the state and shock coords. If
         None, the state names will simply be numbered.
 
@@ -141,7 +141,7 @@ class BayesianVARMAX(PyMCStateSpace):
     def __init__(
         self,
         order: Tuple[int, int],
-        endog_names: List[str] = None,
+        endog_names: list[str] = None,
         k_endog: int = None,
         stationary_initialization: bool = False,
         filter_type: str = "standard",
@@ -200,7 +200,7 @@ class BayesianVARMAX(PyMCStateSpace):
         return names
 
     @property
-    def param_info(self) -> Dict[str, Dict[str, Any]]:
+    def param_info(self) -> dict[str, dict[str, Any]]:
         info = {
             "x0": {
                 "shape": (self.k_states,),
@@ -258,7 +258,7 @@ class BayesianVARMAX(PyMCStateSpace):
         raise NotImplementedError
 
     @property
-    def coords(self) -> Dict[str, Sequence]:
+    def coords(self) -> dict[str, Sequence]:
         coords = make_default_coords(self)
         if self.p > 0:
             coords.update({AR_PARAM_DIM: list(range(1, self.p + 1))})

--- a/pymc_experimental/statespace/models/utilities.py
+++ b/pymc_experimental/statespace/models/utilities.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 import pytensor.tensor as pt
 
@@ -29,7 +27,7 @@ def make_default_coords(ss_mod):
     return coords
 
 
-def cleanup_states(states: List[str]) -> List[str]:
+def cleanup_states(states: list[str]) -> list[str]:
     """
     Remove meaningless symbols from state names
 
@@ -60,25 +58,25 @@ def cleanup_states(states: List[str]) -> List[str]:
     return out
 
 
-def make_harvey_state_names(p, d, q, P, D, Q, S) -> List[str]:
+def make_harvey_state_names(p: int, d: int, q: int, P: int, D: int, Q: int, S: int) -> list[str]:
     """
     Generate informative names for the SARIMA states in the Harvey representation
 
     Parameters
     ----------
-    p, int
+    p: int
         AR order
-    d, int
+    d: int
         Number of ARIMA differences
-    q, int
+    q: int
         MA order
-    P, int
+    P: int
         Seasonal AR order
-    D, int
+    D: int
         Number of seasonal differences
-    Q, int
+    Q: int
         Seasonal MA order
-    S, int
+    S: int
         Seasonal length
 
     Returns
@@ -90,9 +88,7 @@ def make_harvey_state_names(p, d, q, P, D, Q, S) -> List[str]:
     a list of state names that can help users understand what they are getting back from the statespace. In particular,
     it is helpful to know how differences and seasonal differences are incorporated into the model
     """
-    n_diffs = S * D + d
     k_lags = max(p + P * S, q + Q * S + 1)
-    k_states = k_lags + n_diffs
     has_diff = (d + D) > 0
 
     # First state is always data
@@ -111,7 +107,7 @@ def make_harvey_state_names(p, d, q, P, D, Q, S) -> List[str]:
     season_diff = [S, 0]
     curr_state = f"D{arma_diff[0]}^{arma_diff[1]}"
     for i in range(D):
-        states.extend([f"L{j+1}{curr_state}.data" for j in range(S - 1)])
+        states.extend([f"L{j + 1}{curr_state}.data" for j in range(S - 1)])
         season_diff[1] += 1
         curr_state = f"D{arma_diff[0]}^{arma_diff[1]}D{season_diff[0]}^{season_diff[1]}"
         if i != (D - 1):
@@ -124,7 +120,7 @@ def make_harvey_state_names(p, d, q, P, D, Q, S) -> List[str]:
     # Next, we add the time series dynamics states. These don't have a immediately obvious interpretation, so just call
     # them "state_1" .., "state_n".
     suffix = "_star" if "star" in states[-1] else ""
-    states.extend([f"state{suffix}_{i+1}" for i in range(k_lags - 1)])
+    states.extend([f"state{suffix}_{i + 1}" for i in range(k_lags - 1)])
 
     states = cleanup_states(states)
 
@@ -139,19 +135,19 @@ def make_SARIMA_transition_matrix(
 
     Parameters
     ----------
-    p, int
+    p: int
         AR order
-    d, int
+    d: int
         Number of ARIMA differences
-    q, int
+    q: int
         MA order
-    P, int
+    P: int
         Seasonal AR order
-    D, int
+    D: int
         Number of seasonal differences
-    Q, int
+    Q: int
         Seasonal MA order
-    S, int
+    S: int
         Seasonal length
 
     Returns
@@ -200,10 +196,10 @@ def make_SARIMA_transition_matrix(
             \begin{bmatrix} x_{t-1} \\ \Delta x_{t-1} \\ \Delta^2 x_{t-1} \\ x_{t-1}^\star \end{bmatrix}
 
     Next are the seasonal differences. The highest seasonal difference stored in the states is one less than the
-    seasonal difference order, ``D``. That is, if ``D = 1, S = 4``, there will be states :math:``x_{t-1}, x_{t-2}, x_{t-3},
-    x_{t-4}, x_t^\star`, with :math:`x_t^\star = \Delta_4 x_t = x_t - x_{t-4}`. The level state can be recovered by
-    adding :math:`x_t^\star + x_{t-4}`. To accomplish all of this, two things need to be inserted into the transition
-    matrix:
+    seasonal difference order, ``D``. That is, if ``D = 1, S = 4``, there will be states :math:``x_{t-1}, x_{t-2},
+    x_{t-3}, x_{t-4}, x_t^\star`, with :math:`x_t^\star = \Delta_4 x_t = x_t - x_{t-4}`. The level state can be
+    recovered by adding :math:`x_t^\star + x_{t-4}`. To accomplish all of this, two things need to be inserted into the
+    transition matrix:
 
         1. A shifted identity matrix to "roll" the lagged states forward each transition, and
         2. A pair of 1's to recover the level state by adding the last 2 states (:math:`x_t^\star + x_{t-4}`)

--- a/pymc_experimental/tests/statespace/test_SARIMAX.py
+++ b/pymc_experimental/tests/statespace/test_SARIMAX.py
@@ -180,7 +180,7 @@ def pymc_mod(arima_mod):
         ar_params = pm.Normal("ar_params", sigma=0.1, dims=["ar_lag"])
         ma_params = pm.Normal("ma_params", sigma=1, dims=["ma_lag"])
         sigma_state = pm.Exponential("sigma_state", 0.5)
-        arima_mod.build_statespace_graph(data=data)
+        arima_mod.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
 
     return pymc_mod
 
@@ -210,7 +210,8 @@ def pymc_mod_interp(arima_mod_interp):
         ma_params = pm.Normal("ma_params", sigma=1, dims=["ma_lag"])
         sigma_state = pm.Exponential("sigma_state", 0.5)
         sigma_obs = pm.Exponential("sigma_obs", 0.1)
-        arima_mod_interp.build_statespace_graph(data=data)
+
+        arima_mod_interp.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
 
     return pymc_mod
 
@@ -296,9 +297,7 @@ def test_SARIMAX_update_matches_statsmodels(p, d, q, P, D, Q, S, data, rng):
                 ),
             )
 
-        pm.Deterministic(
-            "sigma_state", pt.as_tensor_variable(np.sqrt(np.array([param_d["sigma2"]])))
-        )
+        pm.Deterministic("sigma_state", pt.as_tensor_variable(np.sqrt(param_d["sigma2"])))
 
         mod._insert_random_variables()
         matrices = pm.draw(mod.subbed_ssm)

--- a/pymc_experimental/tests/statespace/test_VARMAX.py
+++ b/pymc_experimental/tests/statespace/test_VARMAX.py
@@ -63,7 +63,7 @@ def pymc_mod(varma_mod, data):
         )
         sigma_obs = pm.Exponential("sigma_obs", 1, dims=["observed_state"])
 
-        varma_mod.build_statespace_graph(data=data)
+        varma_mod.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
 
     return pymc_mod
 
@@ -71,10 +71,8 @@ def pymc_mod(varma_mod, data):
 @pytest.fixture(scope="session")
 def idata(pymc_mod, rng):
     with pymc_mod:
-        # idata = pm.sample(draws=10, tune=0, chains=1, random_seed=rng)
         idata = pm.sample_prior_predictive(samples=10, random_seed=rng)
 
-    # idata.extend(idata_prior)
     return idata
 
 
@@ -158,11 +156,11 @@ def test_all_prior_covariances_are_PSD(filter_output, pymc_mod, rng):
 
 
 parameters = [
-    {"steps": 10, "shock_size": None},
-    {"steps": 10, "shock_size": 1.0},
-    {"steps": 10, "shock_size": np.array([1.0, 0.0, 0.0])},
+    {"n_steps": 10, "shock_size": None},
+    {"n_steps": 10, "shock_size": 1.0},
+    {"n_steps": 10, "shock_size": np.array([1.0, 0.0, 0.0])},
     {
-        "steps": 10,
+        "n_steps": 10,
         "shock_cov": np.array([[1.38, 0.58, -1.84], [0.58, 0.99, -0.82], [-1.84, -0.82, 2.51]]),
     },
     {

--- a/pymc_experimental/tests/statespace/test_coord_assignment.py
+++ b/pymc_experimental/tests/statespace/test_coord_assignment.py
@@ -11,8 +11,6 @@ from pymc_experimental.statespace.models import structural
 from pymc_experimental.statespace.utils.constants import (
     FILTER_OUTPUT_DIMS,
     FILTER_OUTPUT_NAMES,
-    MATRIX_DIMS,
-    MATRIX_NAMES,
     SMOOTHER_OUTPUT_NAMES,
     TIME_DIM,
 )
@@ -85,19 +83,10 @@ def create_model(load_dataset):
             P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=("state", "state_aux"))
             initial_trend = pm.Normal("initial_trend", dims="trend_state")
             sigma_trend = pm.Exponential("sigma_trend", 1, dims="trend_shock")
-            ss_mod.build_statespace_graph(data)
+            ss_mod.build_statespace_graph(data, save_kalman_filter_outputs_in_idata=True)
         return mod
 
     return _create_model
-
-
-@pytest.mark.parametrize("f, warning", func_inputs, ids=function_names)
-def test_matrix_coord_assignment(f, warning, create_model):
-    with warning:
-        pymc_model = create_model(f)
-
-    for matrix in MATRIX_NAMES:
-        assert pymc_model.named_vars_to_dims[matrix] == MATRIX_DIMS[matrix]
 
 
 @pytest.mark.parametrize("f, warning", func_inputs, ids=function_names)

--- a/pymc_experimental/tests/statespace/test_distributions.py
+++ b/pymc_experimental/tests/statespace/test_distributions.py
@@ -92,6 +92,7 @@ def ss_mod_no_me():
 
 @pytest.mark.parametrize("kfilter", filter_names, ids=filter_names)
 def test_loglike_vectors_agree(kfilter, pymc_model):
+    # TODO: This test might be flakey, I've gotten random failures
     ss_mod = structural.LevelTrendComponent(order=2).build(
         "data", verbose=False, filter_type=kfilter
     )
@@ -184,6 +185,8 @@ def test_lgss_with_time_varying_inputs(output_name, rng):
         mod.add_exogenous(trend)
 
         mod._insert_random_variables()
+        mod._insert_data_variables()
+
         matrices = mod.unpack_statespace()
 
         # pylint: disable=unpacking-non-sequence


### PR DESCRIPTION
I had originally done this to facilitate out-of-sample sampling tasks, so I could do e.g. `pm.Flat('T', T)`. The result was that all matrices were saved to the `idata`, creating pretty horrible `pm.model_to_graphviz` outputs like this:

![image](https://github.com/pymc-devs/pymc-experimental/assets/48652735/e2ae0d13-2f0d-433d-923a-1d44a4c4a554)

This also was extremely memory wasteful. Many of the matrices are not random at all, and they were being saved `(chain, draw)` times. 

After this refactor, the matrices are dynamically rebuilt as needed from the parameter samples. The new graphs look like this:

![image](https://github.com/pymc-devs/pymc-experimental/assets/48652735/5d90e59f-1fe9-4650-bb03-06932b46fb54)

There are also some en-passant changes to how exogenous data are handled that breaks the Structural example notebook. I will open a new PR after this one to address that, because I think I finally have it set up to handle forecasting with exogenous data. Basically, I was previously treating exogenous data like a type of "parameter". It's been upgraded to a first-class object, and custom models subclassing `PyMCStateSpace` that use exogenous data will now need to implement `data_names` and `data_info` properties.