### PR TITLE
Fix JAX warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ filterwarnings =[
 
   # bool8, find_common_type, cumproduct, and product had deprecation warnings added in numpy 1.25
   'ignore:.*(\b(pkg_resources\.declare_namespace|np\.bool8|np\.find_common_type|cumproduct|product)\b).*:DeprecationWarning',
+
+  # JAX issues an over-eager warning if os.fork() is called when the JAX module is loaded, even if JAX isn't being used
+  'ignore:os\.fork\(\) was called\.:RuntimeWarning',
 ]
 
 [tool.black]


### PR DESCRIPTION
Closes #305 

JAX warning mentioned https://github.com/pymc-devs/pymc-experimental/issues/305 seems to be caused by using multiple cores when sampling with pm.sample in tests. The JAX test appears to be over-eager, because it is issued even when JAX is not being used, as long as JAX has been imported. 

This PR adds the warning to `filterwarnings` in the `pyproject.toml`, since it doesn't appear to be relevant to the tests its causing to fail. 