### PR TITLE
Bug fixes for `statespace`

### DIFF
--- a/pymc_experimental/statespace/models/structural.py
+++ b/pymc_experimental/statespace/models/structural.py
@@ -1148,6 +1148,7 @@ class TimeSeasonality(Component):
         innovations: bool = True,
         name: Optional[str] = None,
         state_names: Optional[list] = None,
+        pop_state: bool = True,
     ):
         if name is None:
             name = f"Seasonal[s={season_length}]"
@@ -1160,11 +1161,14 @@ class TimeSeasonality(Component):
                 )
             state_names = state_names.copy()
         self.innovations = innovations
+        self.pop_state = pop_state
 
-        # The first state doesn't get a coefficient, it is defined as -sum(state_coefs)
-        # TODO: Can I stash that information in the model somewhere so users don't have to know that?
-        state_0 = state_names.pop(0)
-        k_states = season_length - 1
+        if self.pop_state:
+            # In traditional models, the first state isn't identified, so we can help out the user by automatically
+            # discarding it.
+            # TODO: Can this be stashed and reconstructed automatically somehow?
+            state_names.pop(0)
+            k_states = season_length - 1
 
         super().__init__(
             name=name,

--- a/pymc_experimental/statespace/models/structural.py
+++ b/pymc_experimental/statespace/models/structural.py
@@ -1499,7 +1499,7 @@ class CycleComponent(Component):
             self.ssm["state_cov", :, :] = pt.eye(self.k_posdef) * sigma_cycle**2
 
     def populate_component_properties(self):
-        self.state_names = [f"{self.name}_{f}" for f in ["Sin", "Cos"]]
+        self.state_names = [f"{self.name}_{f}" for f in ["Cos", "Sin"]]
         self.param_names = [f"{self.name}"]
 
         self.param_info = {

--- a/pymc_experimental/statespace/models/structural.py
+++ b/pymc_experimental/statespace/models/structural.py
@@ -20,7 +20,6 @@ from pymc_experimental.statespace.utils.constants import (
     ALL_STATE_DIM,
     AR_PARAM_DIM,
     LONG_MATRIX_NAMES,
-    OBS_STATE_DIM,
     POSITION_DERIVATIVE_NAMES,
     TIME_DIM,
 )
@@ -910,17 +909,17 @@ class MeasurementError(Component):
 
     def populate_component_properties(self):
         self.param_names = [f"sigma_{self.name}"]
-        self.param_dims = {f"sigma_{self.name}": (OBS_STATE_DIM,)}
+        self.param_dims = {}
         self.param_info = {
             f"sigma_{self.name}": {
-                "shape": (self.k_endog,),
+                "shape": (),
                 "constraints": "Positive",
-                "dims": (OBS_STATE_DIM,),
+                "dims": None,
             }
         }
 
     def make_symbolic_graph(self) -> None:
-        sigma_shape = () if self.k_endog == 1 else (self.k_endog,)
+        sigma_shape = ()
         error_sigma = self.make_and_register_variable(f"sigma_{self.name}", shape=sigma_shape)
         diag_idx = np.diag_indices(self.k_endog)
         idx = np.s_["obs_cov", diag_idx[0], diag_idx[1]]

--- a/pymc_experimental/statespace/utils/data_tools.py
+++ b/pymc_experimental/statespace/utils/data_tools.py
@@ -112,7 +112,18 @@ def add_data_to_active_model(values, index):
     if OBS_STATE_DIM in pymc_mod.coords:
         data_dims = [TIME_DIM, OBS_STATE_DIM]
 
-    pymc_mod.add_coord(TIME_DIM, index)
+    if TIME_DIM not in pymc_mod.coords:
+        pymc_mod.add_coord(TIME_DIM, index)
+    else:
+        found_time = pymc_mod.coords[TIME_DIM]
+        if found_time is None:
+            pymc_mod.coords.update({TIME_DIM: index})
+        elif not np.array_equal(found_time, index):
+            raise ValueError(
+                "Provided data has a different time index than the model. Please ensure that the time values "
+                "set on coords matches that of the exogenous data."
+            )
+
     data = pm.Data("data", values, dims=data_dims)
 
     return data

--- a/pymc_experimental/tests/statespace/test_structural.py
+++ b/pymc_experimental/tests/statespace/test_structural.py
@@ -199,7 +199,6 @@ def create_structural_model_and_equivalent_statsmodel(
         sigma2 = np.abs(rng.normal()).astype(floatX).item()
         params["sigma_irregular"] = np.sqrt(sigma2)
         sm_params["sigma2.irregular"] = sigma2
-        expected_param_dims["sigma_irregular"] += ("observed_state",)
 
         comp = st.MeasurementError("irregular")
         components.append(comp)

--- a/pymc_experimental/tests/statespace/test_structural.py
+++ b/pymc_experimental/tests/statespace/test_structural.py
@@ -361,7 +361,7 @@ def create_structural_model_and_equivalent_statsmodel(
         params["cycle"] = init_cycle
         expected_param_dims["cycle"] += ("cycle_state",)
 
-        state_names = ["cycle_Sin", "cycle_Cos"]
+        state_names = ["cycle_Cos", "cycle_Sin"]
         expected_coords["cycle_state"] += state_names
         expected_coords[ALL_STATE_DIM] += state_names
         expected_coords[ALL_STATE_AUX_DIM] += state_names


### PR DESCRIPTION
When I first wrote `StructuralComponent`, I had an idea that every model parameter should have dims associated with it. This had the consequence that even if a parameter should *always* be a scalar, such as standard deviations on shocks, it needed to be given `shape=(1,)` if `dims` were not used. This was a bit silly, so since #296, it has been my intention that scalar-only parameters should be scalars (and have no associated `dims`). #318 points out that the code is currently inconsistent -- some parameters are still having dims generated for them that don't need them, or vice-versa. 

This PR should hopefully clean all this up. Parameters that are always scalars will never have dims associated with them, do not expect a shape argument, and will show `shape=None` in the model info output when `structural_model.build(verbose=True)` is called.

In addition: 
- I re-run the structural notebook to work after recent changes.
- The name "time" can now be used as a dimension before calling `model.build_statespace_graph(observed_data)`. This is useful when setting exogenous data for an `ExogenousComponent`. In this case, a check is added that the index on the data passed to the `build_statespace_graph` is the same as that found on any existing `time` dim.
- `TimeSeasonality` previously always removed the first state because it is not identified. I added an option to keep it to I could test if `ZeroSumNormal` could be used to identify all the states.

Closes #318 , #297