### PR TITLE
Specialized DiscreteMarkovChain step sampler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.6.0

--- a/pymc_experimental/__init__.py
+++ b/pymc_experimental/__init__.py
@@ -13,7 +13,8 @@
 #   limitations under the License.
 import logging
 
-from pymc_experimental import distributions, gp, statespace, utils
+from pymc_experimental import gp, statespace, utils
+from pymc_experimental.distributions import *
 from pymc_experimental.inference.fit import fit
 from pymc_experimental.model.marginal_model import MarginalModel
 from pymc_experimental.model.model_api import as_model
@@ -26,15 +27,3 @@ if not logging.root.handlers:
     if len(_log.handlers) == 0:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
-
-
-__all__ = [
-    "distributions",
-    "gp",
-    "statespace",
-    "utils",
-    "fit",
-    "MarginalModel",
-    "as_model",
-    "__version__",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,4 @@ lines-between-types = 1
   'F401', # Unused import warning for test files -- this check removes imports of fixtures
   'F811'  # Redefine while unused -- this check fails on imported fixtures
 ]
+'pymc_experimental/__init__.py' = ['F401', 'F403']


### PR DESCRIPTION
Closes #324 

It's just `CategoricalGibbsMetropolis` but accepts `DiscreteMarkovChain` and knows how to get the dimensionality of P.

Once we merge DMC into PyMC we can just extend the CategoricalGibbsMetropolis to accept it