### PR TITLE
update pre-commit-config replacing black and pylint with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,17 +20,12 @@ repos:
   hooks:
     - id: pyupgrade
       args: [--py37-plus]
-- repo: https://github.com/psf/black
-  rev: 24.1.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.4
   hooks:
-    - id: black
-    - id: black-jupyter
-- repo: https://github.com/PyCQA/pylint
-  rev: v3.0.3
-  hooks:
-    - id: pylint
-      args: [--rcfile=.pylintrc]
-      files: ^pymc_experimental/
+    - id: ruff
+      args: ["--fix", "--output-format=full"]
+    - id: ruff-format
 - repo: https://github.com/MarcoGorelli/madforhooks
   rev: 0.4.1
   hooks:

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,9 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
 
 
 def pytest_configure(config):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,7 +171,9 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pymc_experimental", "pymc_experimental Documentation", [author], 1)]
+man_pages = [
+    (master_doc, "pymc_experimental", "pymc_experimental Documentation", [author], 1)
+]
 
 
 # -- Options for Texinfo output ----------------------------------------------

--- a/pymc_experimental/__init__.py
+++ b/pymc_experimental/__init__.py
@@ -13,6 +13,10 @@
 #   limitations under the License.
 import logging
 
+from pymc_experimental import distributions, gp, statespace, utils
+from pymc_experimental.inference.fit import fit
+from pymc_experimental.model.marginal_model import MarginalModel
+from pymc_experimental.model.model_api import as_model
 from pymc_experimental.version import __version__
 
 _log = logging.getLogger("pmx")
@@ -23,7 +27,14 @@ if not logging.root.handlers:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
 
-from pymc_experimental import distributions, gp, statespace, utils
-from pymc_experimental.inference.fit import fit
-from pymc_experimental.model.marginal_model import MarginalModel
-from pymc_experimental.model.model_api import as_model
+
+__all__ = [
+    "__version__",
+    "distributions",
+    "gp",
+    "statespace",
+    "utils",
+    "fit",
+    "MarginalModel",
+    "as_model",
+]

--- a/pymc_experimental/distributions/continuous.py
+++ b/pymc_experimental/distributions/continuous.py
@@ -41,7 +41,9 @@ class GenExtremeRV(RandomVariable):
     dtype: str = "floatX"
     _print_name: Tuple[str, str] = ("Generalized Extreme Value", "\\operatorname{GEV}")
 
-    def __call__(self, mu=0.0, sigma=1.0, xi=0.0, size=None, **kwargs) -> TensorVariable:
+    def __call__(
+        self, mu=0.0, sigma=1.0, xi=0.0, size=None, **kwargs
+    ) -> TensorVariable:
         return super().__call__(mu, sigma, xi, size=size, **kwargs)
 
     @classmethod
@@ -54,7 +56,9 @@ class GenExtremeRV(RandomVariable):
         size: Tuple[int, ...],
     ) -> np.ndarray:
         # Notice negative here, since remainder of GenExtreme is based on Coles parametrization
-        return stats.genextreme.rvs(c=-xi, loc=mu, scale=sigma, random_state=rng, size=size)
+        return stats.genextreme.rvs(
+            c=-xi, loc=mu, scale=sigma, random_state=rng, size=size
+        )
 
 
 gev = GenExtremeRV()
@@ -214,7 +218,9 @@ class GenExtreme(Continuous):
         r"""
         Using the mode, as the mean can be infinite when :math:`\xi > 1`
         """
-        mode = pt.switch(pt.isclose(xi, 0), mu, mu + sigma * (pt.pow(1 + xi, -xi) - 1) / xi)
+        mode = pt.switch(
+            pt.isclose(xi, 0), mu, mu + sigma * (pt.pow(1 + xi, -xi) - 1) / xi
+        )
         if not rv_size_is_none(size):
             mode = pt.full(size, mode)
         return mode

--- a/pymc_experimental/distributions/discrete.py
+++ b/pymc_experimental/distributions/discrete.py
@@ -51,14 +51,14 @@ class GeneralizedPoissonRV(RandomVariable):
         x = np.empty(dist_size)
         idxs_mask = np.broadcast_to(lam < 0, dist_size)
         if np.any(idxs_mask):
-            x[idxs_mask] = cls._inverse_rng_fn(rng, theta, lam, dist_size, idxs_mask=idxs_mask)[
-                idxs_mask
-            ]
+            x[idxs_mask] = cls._inverse_rng_fn(
+                rng, theta, lam, dist_size, idxs_mask=idxs_mask
+            )[idxs_mask]
         idxs_mask = ~idxs_mask
         if np.any(idxs_mask):
-            x[idxs_mask] = cls._branching_rng_fn(rng, theta, lam, dist_size, idxs_mask=idxs_mask)[
-                idxs_mask
-            ]
+            x[idxs_mask] = cls._branching_rng_fn(
+                rng, theta, lam, dist_size, idxs_mask=idxs_mask
+            )[idxs_mask]
         return x
 
     @classmethod
@@ -159,7 +159,9 @@ class GeneralizedPoisson(pm.distributions.Discrete):
 
     def logp(value, mu, lam):
         mu_lam_value = mu + lam * value
-        logprob = np.log(mu) + logpow(mu_lam_value, value - 1) - mu_lam_value - factln(value)
+        logprob = (
+            np.log(mu) + logpow(mu_lam_value, value - 1) - mu_lam_value - factln(value)
+        )
 
         # Probability is 0 when value > m, where m is the largest positive integer for
         # which mu + m * lam > 0 (when lam < 0).

--- a/pymc_experimental/distributions/multivariate/__init__.py
+++ b/pymc_experimental/distributions/multivariate/__init__.py
@@ -1,1 +1,3 @@
 from pymc_experimental.distributions.multivariate.r2d2m2cp import R2D2M2CP
+
+__all__ = ["R2D2M2CP"]

--- a/pymc_experimental/distributions/multivariate/r2d2m2cp.py
+++ b/pymc_experimental/distributions/multivariate/r2d2m2cp.py
@@ -92,7 +92,9 @@ def _R2D2M2CP_beta(
                 raw = pt.zeros_like(mu_param)
             else:
                 raw = pm.Normal("raw", dims=dims)
-        beta = pm.Deterministic(name, (raw * std_param + mu_param) / input_sigma, dims=dims)
+        beta = pm.Deterministic(
+            name, (raw * std_param + mu_param) / input_sigma, dims=dims
+        )
     else:
         if psi_mask is not None and psi_mask.any():
             # limit case where some probs are not 1 or 0
@@ -113,7 +115,9 @@ def _R2D2M2CP_beta(
             # all variables are deterministic
             beta = pm.Deterministic(name, (mu_param / input_sigma), dims=dims)
         else:
-            beta = pm.Normal(name, mu_param / input_sigma, std_param / input_sigma, dims=dims)
+            beta = pm.Normal(
+                name, mu_param / input_sigma, std_param / input_sigma, dims=dims
+            )
     return beta
 
 
@@ -137,7 +141,8 @@ def _psi_masked(
     dims: Sequence[str],
 ) -> Tuple[Union[pt.TensorLike, None], pt.TensorVariable]:
     if not (
-        isinstance(positive_probs, pt.Constant) and isinstance(positive_probs_std, pt.Constant)
+        isinstance(positive_probs, pt.Constant)
+        and isinstance(positive_probs_std, pt.Constant)
     ):
         raise TypeError(
             "Only constant values for positive_probs and positive_probs_std are accepted"
@@ -147,7 +152,9 @@ def _psi_masked(
     )
     mask = ~np.bitwise_or(positive_probs == 1, positive_probs == 0)
     if np.bitwise_and(~mask, positive_probs_std != 0).any():
-        raise ValueError("Can't have both positive_probs == '1 or 0' and positive_probs_std != 0")
+        raise ValueError(
+            "Can't have both positive_probs == '1 or 0' and positive_probs_std != 0"
+        )
     if (~mask).any() and mask.any():
         # limit case where some probs are not 1 or 0
         # setsubtensor is required
@@ -206,7 +213,9 @@ def _phi(
         if variance_explained is not None:
             raise TypeError("Can't use variable importance with variance explained")
         if len(model.coords[dim]) <= 1:
-            raise TypeError("Can't use variable importance with less than two variables")
+            raise TypeError(
+                "Can't use variable importance with less than two variables"
+            )
         variables_importance = pt.as_tensor(variables_importance)
         if importance_concentration is not None:
             variables_importance *= importance_concentration
@@ -218,7 +227,9 @@ def _phi(
     else:
         phi = _broadcast_as_dims(1.0, dims=dims)
     if importance_concentration is not None:
-        return pm.Dirichlet("phi", importance_concentration * phi, dims=broadcast_dims + [dim])
+        return pm.Dirichlet(
+            "phi", importance_concentration * phi, dims=broadcast_dims + [dim]
+        )
     else:
         return phi
 
@@ -428,7 +439,9 @@ def R2D2M2CP(
             dims=dims,
         )
         mask, psi = _psi(
-            positive_probs=positive_probs, positive_probs_std=positive_probs_std, dims=dims
+            positive_probs=positive_probs,
+            positive_probs_std=positive_probs_std,
+            dims=dims,
         )
 
     beta = _R2D2M2CP_beta(

--- a/pymc_experimental/distributions/timeseries.py
+++ b/pymc_experimental/distributions/timeseries.py
@@ -26,7 +26,9 @@ from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
 
 
-def _make_outputs_info(n_lags: int, init_dist: Distribution) -> List[Union[Distribution, dict]]:
+def _make_outputs_info(
+    n_lags: int, init_dist: Distribution
+) -> List[Union[Distribution, dict]]:
     """
     Two cases are needed for outputs_info in the scans used by DiscreteMarkovRv. If n_lags = 1, we need to throw away
     the first dimension of init_dist_ or else markov_chain will have shape (steps, 1, *batch_size) instead of
@@ -124,7 +126,9 @@ class DiscreteMarkovChain(Distribution):
     @classmethod
     def dist(cls, P=None, logit_P=None, steps=None, init_dist=None, n_lags=1, **kwargs):
         steps = get_support_shape_1d(
-            support_shape=steps, shape=kwargs.get("shape", None), support_shape_offset=n_lags
+            support_shape=steps,
+            shape=kwargs.get("shape", None),
+            support_shape_offset=n_lags,
         )
 
         if steps is None:
@@ -199,7 +203,9 @@ class DiscreteMarkovChain(Distribution):
 
         (state_next_rng,) = tuple(state_updates.values())
 
-        discrete_mc_ = pt.moveaxis(pt.concatenate([init_dist_, markov_chain], axis=0), 0, -1)
+        discrete_mc_ = pt.moveaxis(
+            pt.concatenate([init_dist_, markov_chain], axis=0), 0, -1
+        )
 
         discrete_mc_op = DiscreteMarkovChainRV(
             inputs=[P_, steps_, init_dist_, state_rng],
@@ -218,7 +224,9 @@ def change_mc_size(op, dist, new_size, expand=False):
         old_size = dist.shape[:-1]
         new_size = tuple(new_size) + tuple(old_size)
 
-    return DiscreteMarkovChain.rv_op(*dist.owner.inputs[:-1], size=new_size, n_lags=op.n_lags)
+    return DiscreteMarkovChain.rv_op(
+        *dist.owner.inputs[:-1], size=new_size, n_lags=op.n_lags
+    )
 
 
 @_support_point.register(DiscreteMarkovChainRV)
@@ -247,7 +255,10 @@ def discrete_mc_logp(op, values, P, steps, init_dist, state_rng, **kwargs):
     value = values[0]
     n_lags = op.n_lags
 
-    indexes = [value[..., i : -(n_lags - i) if n_lags != i else None] for i in range(n_lags + 1)]
+    indexes = [
+        value[..., i : -(n_lags - i) if n_lags != i else None]
+        for i in range(n_lags + 1)
+    ]
 
     mc_logprob = logp(init_dist, value[..., :n_lags]).sum(axis=-1)
     mc_logprob += pt.log(P[tuple(indexes)]).sum(axis=-1)

--- a/pymc_experimental/gp/__init__.py
+++ b/pymc_experimental/gp/__init__.py
@@ -14,3 +14,5 @@
 
 
 from pymc_experimental.gp.latent_approx import KarhunenLoeveExpansion, ProjectedProcess
+
+__all__ = ["KarhunenLoeveExpansion", "ProjectedProcess"]

--- a/pymc_experimental/gp/latent_approx.py
+++ b/pymc_experimental/gp/latent_approx.py
@@ -47,7 +47,9 @@ class ProjectedProcess(pm.gp.Latent):
         L = cholesky(stabilize(Kuu, jitter))
 
         n_inducing_points = np.shape(X_inducing)[0]
-        v = pm.Normal(name + "_u_rotated_", mu=0.0, sigma=1.0, size=n_inducing_points, **kwargs)
+        v = pm.Normal(
+            name + "_u_rotated_", mu=0.0, sigma=1.0, size=n_inducing_points, **kwargs
+        )
         u = pm.Deterministic(name + "_u", L @ v)
 
         Kfu = self.cov_func(X, X_inducing)
@@ -111,7 +113,9 @@ class ProjectedProcess(pm.gp.Latent):
         Ksu = self.cov_func(Xnew, X_inducing)
         mu = self.mean_func(Xnew) + Ksu @ Kuuiu
         tmp = solve_lower(L, pt.transpose(Ksu))
-        Qss = pt.transpose(tmp) @ tmp  # Qss = tt.dot(tt.dot(Ksu, tt.nlinalg.pinv(Kuu)), Ksu.T)
+        Qss = (
+            pt.transpose(tmp) @ tmp
+        )  # Qss = tt.dot(tt.dot(Ksu, tt.nlinalg.pinv(Kuu)), Ksu.T)
         Kss = self.cov_func(Xnew)
         Lss = cholesky(stabilize(Kss - Qss, jitter))
         return mu, Lss
@@ -137,7 +141,7 @@ class KarhunenLoeveExpansion(pm.gp.Latent):
         super().__init__(mean_func=mean_func, cov_func=cov_func)
 
     def _build_prior(self, name, X, jitter=1e-6, **kwargs):
-        mu = self.mean_func(X)
+        # mu = self.mean_func(X)
         Kxx = pm.gp.util.stabilize(self.cov_func(X), jitter)
         vals, vecs = pt.linalg.eigh(Kxx)
         ## NOTE: REMOVED PRECISION CUTOFF
@@ -147,7 +151,9 @@ class KarhunenLoeveExpansion(pm.gp.Latent):
             if self.variance_limit == 1:
                 n_eigs = len(vals)
             else:
-                n_eigs = ((vals[::-1].cumsum() / vals.sum()) > self.variance_limit).nonzero()[0][0]
+                n_eigs = (
+                    (vals[::-1].cumsum() / vals.sum()) > self.variance_limit
+                ).nonzero()[0][0]
         U = vecs[:, -n_eigs:]
         s = vals[-n_eigs:]
         basis = U * pt.sqrt(s)

--- a/pymc_experimental/inference/__init__.py
+++ b/pymc_experimental/inference/__init__.py
@@ -14,3 +14,5 @@
 
 
 from pymc_experimental.inference.fit import fit
+
+__all__ = ["fit"]

--- a/pymc_experimental/inference/fit.py
+++ b/pymc_experimental/inference/fit.py
@@ -31,7 +31,7 @@ def fit(method, **kwargs):
     """
     if method == "pathfinder":
         try:
-            import blackjax
+            import blackjax  # noqa: F401
         except ImportError as exc:
             raise RuntimeError("Need BlackJAX to use `pathfinder`") from exc
 
@@ -40,7 +40,6 @@ def fit(method, **kwargs):
         return fit_pathfinder(**kwargs)
 
     if method == "laplace":
-
         from pymc_experimental.inference.laplace import laplace
 
         return laplace(**kwargs)

--- a/pymc_experimental/inference/laplace.py
+++ b/pymc_experimental/inference/laplace.py
@@ -146,11 +146,15 @@ def addFitToInferenceData(vars, idata, mean, covariance):
     # Convert to xarray DataArray
     mean_dataarray = xr.DataArray(mean, dims=["rows"], coords={"rows": coord_names})
     cov_dataarray = xr.DataArray(
-        covariance, dims=["rows", "columns"], coords={"rows": coord_names, "columns": coord_names}
+        covariance,
+        dims=["rows", "columns"],
+        coords={"rows": coord_names, "columns": coord_names},
     )
 
     # Create xarray dataset
-    dataset = xr.Dataset({"mean_vector": mean_dataarray, "covariance_matrix": cov_dataarray})
+    dataset = xr.Dataset(
+        {"mean_vector": mean_dataarray, "covariance_matrix": cov_dataarray}
+    )
 
     idata.add_groups(fit=dataset)
 

--- a/pymc_experimental/inference/pathfinder.py
+++ b/pymc_experimental/inference/pathfinder.py
@@ -48,7 +48,9 @@ def convert_flat_trace_to_idata(
     trace = {k: np.asarray(v)[None, ...] for k, v in trace.items()}
 
     var_names = model.unobserved_value_vars
-    vars_to_sample = list(get_default_varnames(var_names, include_transformed=include_transformed))
+    vars_to_sample = list(
+        get_default_varnames(var_names, include_transformed=include_transformed)
+    )
     print("Transforming variables...", file=sys.stdout)
     jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=vars_to_sample)
     result = jax.vmap(jax.vmap(jax_fn))(

--- a/pymc_experimental/inference/smc/sampling.py
+++ b/pymc_experimental/inference/smc/sampling.py
@@ -198,7 +198,9 @@ def arviz_from_particles(model, particles):
     -------
     """
     n_particles = jax.tree_util.tree_flatten(particles)[0][0].shape[0]
-    by_varname = {k.name: v.squeeze()[np.newaxis, :] for k, v in zip(model.value_vars, particles)}
+    by_varname = {
+        k.name: v.squeeze()[np.newaxis, :] for k, v in zip(model.value_vars, particles)
+    }
     varnames = [v.name for v in model.value_vars]
     with model:
         strace = NDArray(name=model.name)
@@ -344,18 +346,18 @@ def add_to_inference_data(
         "sampler": f"Blackjax SMC with {kernel} kernel",
     }
 
-    inference_data.posterior.attrs["lambda_evolution"] = np.array(diagnosis.lmbda_evolution)[
-        :iterations_to_diagnose
-    ]
+    inference_data.posterior.attrs["lambda_evolution"] = np.array(
+        diagnosis.lmbda_evolution
+    )[:iterations_to_diagnose]
     inference_data.posterior.attrs["log_likelihood_increments"] = np.array(
         diagnosis.log_likelihood_increment_evolution
     )[:iterations_to_diagnose]
-    inference_data.posterior.attrs["ancestors_evolution"] = np.array(diagnosis.ancestors_evolution)[
-        :iterations_to_diagnose
-    ]
-    inference_data.posterior.attrs["weights_evolution"] = np.array(diagnosis.weights_evolution)[
-        :iterations_to_diagnose
-    ]
+    inference_data.posterior.attrs["ancestors_evolution"] = np.array(
+        diagnosis.ancestors_evolution
+    )[:iterations_to_diagnose]
+    inference_data.posterior.attrs["weights_evolution"] = np.array(
+        diagnosis.weights_evolution
+    )[:iterations_to_diagnose]
 
     for k in experiment_parameters:
         inference_data.posterior.attrs[k] = experiment_parameters[k]
@@ -391,7 +393,9 @@ def get_jaxified_particles_fn(model, graph_outputs):
 
 def initialize_population(model, draws, random_seed) -> Dict[str, np.ndarray]:
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning, message="The effect of Potentials")
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, message="The effect of Potentials"
+        )
 
         prior_expression = make_initial_point_expression(
             free_rvs=model.free_RVs,

--- a/pymc_experimental/linearmodel.py
+++ b/pymc_experimental/linearmodel.py
@@ -8,7 +8,9 @@ from pymc_experimental.model_builder import ModelBuilder
 
 
 class LinearModel(ModelBuilder):
-    def __init__(self, model_config: Dict = None, sampler_config: Dict = None, nsamples=100):
+    def __init__(
+        self, model_config: Dict = None, sampler_config: Dict = None, nsamples=100
+    ):
         self.nsamples = nsamples
         super().__init__(model_config, sampler_config)
 
@@ -80,10 +82,12 @@ class LinearModel(ModelBuilder):
             obs_error = pm.HalfNormal("σ_model_fmc", cfg["obs_error"])
 
             # Model
-            y_model = pm.Deterministic("y_model", intercept + slope * x, dims="observation")
+            y_model = pm.Deterministic(
+                "y_model", intercept + slope * x, dims="observation"
+            )
 
             # observed data
-            y_hat = pm.Normal(
+            pm.Normal(
                 "y_hat",
                 y_model,
                 sigma=obs_error,
@@ -94,7 +98,9 @@ class LinearModel(ModelBuilder):
 
         self._data_setter(X, y)
 
-    def _data_setter(self, X: pd.DataFrame, y: Optional[Union[pd.DataFrame, pd.Series]] = None):
+    def _data_setter(
+        self, X: pd.DataFrame, y: Optional[Union[pd.DataFrame, pd.Series]] = None
+    ):
         with self.model:
             pm.set_data({"x": X.squeeze()})
             if y is not None:

--- a/pymc_experimental/model/transforms/autoreparam.py
+++ b/pymc_experimental/model/transforms/autoreparam.py
@@ -42,7 +42,9 @@ class VIP:
     _logit_lambda: Dict[str, pytensor.tensor.sharedvar.TensorSharedVariable]
 
     @property
-    def variational_parameters(self) -> List[pytensor.tensor.sharedvar.TensorSharedVariable]:
+    def variational_parameters(
+        self,
+    ) -> List[pytensor.tensor.sharedvar.TensorSharedVariable]:
         r"""Return raw :math:`\operatorname{logit}(\lambda_k)` for custom optimization.
 
         Examples
@@ -222,7 +224,9 @@ def _(
 ) -> ModelDeterministic:
     rng, size, loc, scale = node.inputs
     if transform is not None:
-        raise NotImplementedError("Reparametrization of Normal with Transform is not implemented")
+        raise NotImplementedError(
+            "Reparametrization of Normal with Transform is not implemented"
+        )
     vip_rv_ = pm.Normal.dist(
         lam * loc,
         scale**lam,
@@ -418,6 +422,6 @@ def vip_reparametrize(
         lambda_names.append(lam.name)
     toposort_replace(fmodel, replacements, reverse=True)
     reparam_model = model_from_fgraph(fmodel)
-    model_lambdas = {n: reparam_model[l] for l, n in zip(lambda_names, var_names)}
+    model_lambdas = {n: reparam_model[lam] for lam, n in zip(lambda_names, var_names)}
     vip = VIP(model_lambdas)
     return reparam_model, vip

--- a/pymc_experimental/model_builder.py
+++ b/pymc_experimental/model_builder.py
@@ -72,19 +72,27 @@ class ModelBuilder:
         >>> model = MyModel(model_config, sampler_config)
         """
         sampler_config = (
-            self.get_default_sampler_config() if sampler_config is None else sampler_config
+            self.get_default_sampler_config()
+            if sampler_config is None
+            else sampler_config
         )
         self.sampler_config = sampler_config
-        model_config = self.get_default_model_config() if model_config is None else model_config
+        model_config = (
+            self.get_default_model_config() if model_config is None else model_config
+        )
 
         self.model_config = model_config  # parameters for priors etc.
         self.model = None  # Set by build_model
-        self.idata: Optional[az.InferenceData] = None  # idata is generated during fitting
+        self.idata: Optional[az.InferenceData] = (
+            None  # idata is generated during fitting
+        )
         self.is_fitted_ = False
 
     def _validate_data(self, X, y=None):
         if y is not None:
-            return check_X_y(X, y, accept_sparse=False, y_numeric=True, multi_output=False)
+            return check_X_y(
+                X, y, accept_sparse=False, y_numeric=True, multi_output=False
+            )
         else:
             return check_array(X, accept_sparse=False)
 
@@ -396,10 +404,14 @@ class ModelBuilder:
                     if isinstance(model_config[key][sub_key], list):
                         # Check if "dims" key to convert it to tuple
                         if sub_key == "dims":
-                            model_config[key][sub_key] = tuple(model_config[key][sub_key])
+                            model_config[key][sub_key] = tuple(
+                                model_config[key][sub_key]
+                            )
                         # Convert all other lists to numpy arrays
                         else:
-                            model_config[key][sub_key] = np.array(model_config[key][sub_key])
+                            model_config[key][sub_key] = np.array(
+                                model_config[key][sub_key]
+                            )
         return model_config
 
     @classmethod
@@ -431,7 +443,9 @@ class ModelBuilder:
         filepath = Path(str(fname))
         idata = az.from_netcdf(filepath)
         # needs to be converted, because json.loads was changing tuple to list
-        model_config = cls._model_config_formatting(json.loads(idata.attrs["model_config"]))
+        model_config = cls._model_config_formatting(
+            json.loads(idata.attrs["model_config"])
+        )
         model = cls(
             model_config=model_config,
             sampler_config=json.loads(idata.attrs["sampler_config"]),
@@ -612,7 +626,9 @@ class ModelBuilder:
                 else:
                     self.idata = prior_pred
 
-        prior_predictive_samples = az.extract(prior_pred, "prior_predictive", combined=combined)
+        prior_predictive_samples = az.extract(
+            prior_pred, "prior_predictive", combined=combined
+        )
 
         return prior_predictive_samples
 

--- a/pymc_experimental/statespace/core/representation.py
+++ b/pymc_experimental/statespace/core/representation.py
@@ -223,7 +223,9 @@ class PytensorRepresentation:
         if key not in self.shapes:
             raise IndexError(f"{key} is an invalid state space matrix name")
 
-    def _update_shape(self, key: KeyLike, value: Union[np.ndarray, pt.Variable]) -> None:
+    def _update_shape(
+        self, key: KeyLike, value: Union[np.ndarray, pt.Variable]
+    ) -> None:
         if isinstance(value, (pt.TensorConstant, pt.TensorVariable)):
             shape = value.type.shape
         else:
@@ -231,7 +233,9 @@ class PytensorRepresentation:
 
         old_shape = self.shapes[key]
         ndim_core = 1 if key in VECTOR_VALUED else 2
-        if not all([a == b for a, b in zip(shape[-ndim_core:], old_shape[-ndim_core:])]):
+        if not all(
+            [a == b for a, b in zip(shape[-ndim_core:], old_shape[-ndim_core:])]
+        ):
             raise ValueError(
                 f"The last two dimensions of {key} must be {old_shape[-ndim_core:]}, found {shape[-ndim_core:]}"
             )
@@ -269,7 +273,9 @@ class PytensorRepresentation:
 
         return type(key)
 
-    def _validate_matrix_shape(self, name: str, X: Union[np.ndarray, pt.TensorVariable]) -> None:
+    def _validate_matrix_shape(
+        self, name: str, X: Union[np.ndarray, pt.TensorVariable]
+    ) -> None:
         time_dim, *expected_shape = self.shapes[name]
         expected_shape = tuple(expected_shape)
         shape = X.shape if isinstance(X, np.ndarray) else X.type.shape
@@ -328,7 +334,9 @@ class PytensorRepresentation:
             #         f"provided data)"
             #     )
 
-    def _check_provided_tensor(self, name: str, X: pt.TensorVariable) -> pt.TensorVariable:
+    def _check_provided_tensor(
+        self, name: str, X: pt.TensorVariable
+    ) -> pt.TensorVariable:
         self._validate_matrix_shape(name, X)
         if name not in NEVER_TIME_VARYING:
             if X.ndim == 1 and name in VECTOR_VALUED:
@@ -407,7 +415,9 @@ class PytensorRepresentation:
         else:
             raise IndexError("First index must the name of a valid state space matrix.")
 
-    def __setitem__(self, key: KeyLike, value: Union[float, int, np.ndarray, pt.Variable]) -> None:
+    def __setitem__(
+        self, key: KeyLike, value: Union[float, int, np.ndarray, pt.Variable]
+    ) -> None:
         _type = type(key)
 
         # Case 1: key is a string: we are setting an entire matrix.

--- a/pymc_experimental/statespace/core/statespace.py
+++ b/pymc_experimental/statespace/core/statespace.py
@@ -64,7 +64,9 @@ def _validate_filter_arg(filter_arg):
 
 def _verify_group(group):
     if group not in ["prior", "posterior"]:
-        raise ValueError(f'Argument "group" must be one of "prior" or "posterior", found {group}')
+        raise ValueError(
+            f'Argument "group" must be one of "prior" or "posterior", found {group}'
+        )
 
 
 class PyMCStateSpace:
@@ -244,11 +246,14 @@ class PyMCStateSpace:
 
         if filter_type.lower() not in FILTER_FACTORY.keys():
             raise NotImplementedError(
-                "The following are valid filter types: " + ", ".join(list(FILTER_FACTORY.keys()))
+                "The following are valid filter types: "
+                + ", ".join(list(FILTER_FACTORY.keys()))
             )
 
         if filter_type == "single" and self.k_endog > 1:
-            raise ValueError('Cannot use filter_type = "single" with multiple observed time series')
+            raise ValueError(
+                'Cannot use filter_type = "single" with multiple observed time series'
+            )
 
         self.kalman_filter = FILTER_FACTORY[filter_type.lower()]()
         self.kalman_smoother = KalmanSmoother()
@@ -395,7 +400,9 @@ class PyMCStateSpace:
         """
         A k_endog length list of strings, associated with the model's observed states
         """
-        raise NotImplementedError("The observed_states property has not been implemented!")
+        raise NotImplementedError(
+            "The observed_states property has not been implemented!"
+        )
 
     @property
     def shock_names(self) -> list[str]:
@@ -413,7 +420,9 @@ class PyMCStateSpace:
         Returns a dictionary with param_name: Callable key-value pairs. Used by the ``add_default_priors()`` method
         to automatically add priors to the PyMC model.
         """
-        raise NotImplementedError("The default_priors property has not been implemented!")
+        raise NotImplementedError(
+            "The default_priors property has not been implemented!"
+        )
 
     @property
     def coords(self) -> dict[str, Sequence[str]]:
@@ -442,7 +451,9 @@ class PyMCStateSpace:
         """
         Add default priors to the active PyMC model context
         """
-        raise NotImplementedError("The add_default_priors property has not been implemented!")
+        raise NotImplementedError(
+            "The add_default_priors property has not been implemented!"
+        )
 
     def make_and_register_variable(
         self, name, shape: int | tuple[int] | None = None, dtype=floatX
@@ -584,7 +595,9 @@ class PyMCStateSpace:
             self.ssm['selection', 1:, 0] = theta_params
             self.ssm['state_cov', 0, 0] = sigma
         """
-        raise NotImplementedError("The make_symbolic_statespace method has not been implemented!")
+        raise NotImplementedError(
+            "The make_symbolic_statespace method has not been implemented!"
+        )
 
     def _get_matrix_shape_and_dims(
         self, name: str
@@ -694,7 +707,9 @@ class PyMCStateSpace:
 
         matrices = list(self._unpack_statespace_with_placeholders())
 
-        replacement_dict = {var: pymc_model[name] for name, var in self._name_to_variable.items()}
+        replacement_dict = {
+            var: pymc_model[name] for name, var in self._name_to_variable.items()
+        }
         self.subbed_ssm = graph_replace(matrices, replace=replacement_dict, strict=True)
 
     def _insert_data_variables(self):
@@ -724,8 +739,12 @@ class PyMCStateSpace:
                 + ", ".join(missing_data)
             )
 
-        replacement_dict = {data: pymc_model[name] for name, data in self._name_to_data.items()}
-        self.subbed_ssm = graph_replace(self.subbed_ssm, replace=replacement_dict, strict=True)
+        replacement_dict = {
+            data: pymc_model[name] for name, data in self._name_to_data.items()
+        }
+        self.subbed_ssm = graph_replace(
+            self.subbed_ssm, replace=replacement_dict, strict=True
+        )
 
     def _register_matrices_with_pymc_model(self) -> list[pt.TensorVariable]:
         """
@@ -759,7 +778,9 @@ class PyMCStateSpace:
         return registered_matrices
 
     @staticmethod
-    def _register_kalman_filter_outputs_with_pymc_model(outputs: tuple[pt.TensorVariable]) -> None:
+    def _register_kalman_filter_outputs_with_pymc_model(
+        outputs: tuple[pt.TensorVariable],
+    ) -> None:
         mod = modelcontext(None)
         coords = mod.coords
 
@@ -781,7 +802,9 @@ class PyMCStateSpace:
         with mod:
             for var, name in zip(states + covs, state_names + cov_names):
                 dim_names = FILTER_OUTPUT_DIMS.get(name, None)
-                dims = tuple([dim if dim in coords.keys() else None for dim in dim_names])
+                dims = tuple(
+                    [dim if dim in coords.keys() else None for dim in dim_names]
+                )
                 pm.Deterministic(name, var, dims=dims)
 
     def build_statespace_graph(
@@ -870,13 +893,18 @@ class PyMCStateSpace:
         filtered_covariances, predicted_covariances, observed_covariances = covs
         if save_kalman_filter_outputs_in_idata:
             smooth_states, smooth_covariances = self._build_smoother_graph(
-                filtered_states, filtered_covariances, self.unpack_statespace(), mode=mode
+                filtered_states,
+                filtered_covariances,
+                self.unpack_statespace(),
+                mode=mode,
             )
             all_kf_outputs = states + [smooth_states] + covs + [smooth_covariances]
             self._register_kalman_filter_outputs_with_pymc_model(all_kf_outputs)
 
         obs_dims = FILTER_OUTPUT_DIMS["predicted_observed_state"]
-        obs_dims = obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
+        obs_dims = (
+            obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
+        )
 
         SequenceMvNormal(
             "obs",
@@ -934,7 +962,13 @@ class PyMCStateSpace:
             *_, T, Z, R, H, Q = matrices
 
             smooth_states, smooth_covariances = self.kalman_smoother.build_graph(
-                T, R, Q, filtered_states, filtered_covariances, mode=mode, cov_jitter=cov_jitter
+                T,
+                R,
+                Q,
+                filtered_states,
+                filtered_covariances,
+                mode=mode,
+                cov_jitter=cov_jitter,
             )
             smooth_states.name = "smooth_states"
             smooth_covariances.name = "smooth_covariances"
@@ -963,7 +997,9 @@ class PyMCStateSpace:
         self,
         data: pt.TensorLike | None = None,
         data_dims: str | tuple[str] | list[str] | None = None,
-    ) -> tuple[list[pt.TensorVariable], list[tuple[pt.TensorVariable, pt.TensorVariable]]]:
+    ) -> tuple[
+        list[pt.TensorVariable], list[tuple[pt.TensorVariable, pt.TensorVariable]]
+    ]:
         """
         Builds a Kalman filter graph using "dummy" pm.Flat distributions for the model variables and sorts the returns
         into (mean, covariance) pairs for each of filtered, predicted, and smoothed output.
@@ -1084,29 +1120,36 @@ class PyMCStateSpace:
         group_idata = getattr(idata, group)
 
         with pm.Model(coords=self._fit_coords) as forward_model:
-            [
-                x0,
-                P0,
-                c,
-                d,
-                T,
-                Z,
-                R,
-                H,
-                Q,
-            ], grouped_outputs = self._kalman_filter_outputs_from_dummy_graph(data=data)
+            (
+                [
+                    x0,
+                    P0,
+                    c,
+                    d,
+                    T,
+                    Z,
+                    R,
+                    H,
+                    Q,
+                ],
+                grouped_outputs,
+            ) = self._kalman_filter_outputs_from_dummy_graph(data=data)
 
             for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs):
                 dummy_ll = pt.zeros_like(mu)
 
                 state_dims = (
                     (TIME_DIM, ALL_STATE_DIM)
-                    if all([dim in self._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]])
+                    if all(
+                        [dim in self._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]]
+                    )
                     else (None, None)
                 )
                 obs_dims = (
                     (TIME_DIM, OBS_STATE_DIM)
-                    if all([dim in self._fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]])
+                    if all(
+                        [dim in self._fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]]
+                    )
                     else (None, None)
                 )
 
@@ -1218,10 +1261,17 @@ class PyMCStateSpace:
         else:
             steps = len(temp_coords[TIME_DIM]) - 1
 
-        if all([dim in self._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]]):
+        if all(
+            [
+                dim in self._fit_coords
+                for dim in [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
+            ]
+        ):
             dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
-        with pm.Model(coords=temp_coords if dims is not None else None) as forward_model:
+        with pm.Model(
+            coords=temp_coords if dims is not None else None
+        ) as forward_model:
             self._build_dummy_graph()
             self._insert_random_variables()
 
@@ -1234,7 +1284,8 @@ class PyMCStateSpace:
 
             if not self.measurement_error:
                 H_jittered = pm.Deterministic(
-                    "H_jittered", pt.specify_shape(stabilize(H), (self.k_endog, self.k_endog))
+                    "H_jittered",
+                    pt.specify_shape(stabilize(H), (self.k_endog, self.k_endog)),
                 )
                 matrices = [x0, P0, c, d, T, Z, R, H_jittered, Q]
 
@@ -1470,7 +1521,10 @@ class PyMCStateSpace:
                 long_name = SHORT_NAME_TO_LONG[short_name]
                 if (long_name in matrix_names) or (short_name in matrix_names):
                     name = long_name if long_name in matrix_names else short_name
-                    dims = [x if x in self._fit_coords else None for x in MATRIX_DIMS[short_name]]
+                    dims = [
+                        x if x in self._fit_coords else None
+                        for x in MATRIX_DIMS[short_name]
+                    ]
                     pm.Deterministic(name, matrix, dims=dims)
 
         # TODO: Remove this after pm.Flat has its initial_value fixed
@@ -1565,7 +1619,12 @@ class PyMCStateSpace:
         filter_time_dim = TIME_DIM
 
         dims = None
-        if all([dim in temp_coords for dim in [filter_time_dim, ALL_STATE_DIM, OBS_STATE_DIM]]):
+        if all(
+            [
+                dim in temp_coords
+                for dim in [filter_time_dim, ALL_STATE_DIM, OBS_STATE_DIM]
+            ]
+        ):
             dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
         time_index = temp_coords[filter_time_dim]
@@ -1599,22 +1658,30 @@ class PyMCStateSpace:
         temp_coords[TIME_DIM] = forecast_index
 
         mu_dims, cov_dims = None, None
-        if all([dim in self._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]]):
+        if all(
+            [
+                dim in self._fit_coords
+                for dim in [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]
+            ]
+        ):
             mu_dims = ["data_time", ALL_STATE_DIM]
             cov_dims = ["data_time", ALL_STATE_DIM, ALL_STATE_AUX_DIM]
 
         with pm.Model(coords=temp_coords) as forecast_model:
-            [
-                x0,
-                P0,
-                c,
-                d,
-                T,
-                Z,
-                R,
-                H,
-                Q,
-            ], grouped_outputs = self._kalman_filter_outputs_from_dummy_graph(
+            (
+                [
+                    x0,
+                    P0,
+                    c,
+                    d,
+                    T,
+                    Z,
+                    R,
+                    H,
+                    Q,
+                ],
+                grouped_outputs,
+            ) = self._kalman_filter_outputs_from_dummy_graph(
                 data_dims=["data_time", OBS_STATE_DIM]
             )
             group_idx = FILTER_OUTPUT_TYPES.index(filter_output)
@@ -1622,10 +1689,14 @@ class PyMCStateSpace:
             mu, cov = grouped_outputs[group_idx]
 
             x0 = pm.Deterministic(
-                "x0_slice", mu[t0_idx], dims=mu_dims[1:] if mu_dims is not None else None
+                "x0_slice",
+                mu[t0_idx],
+                dims=mu_dims[1:] if mu_dims is not None else None,
             )
             P0 = pm.Deterministic(
-                "P0_slice", cov[t0_idx], dims=cov_dims[1:] if cov_dims is not None else None
+                "P0_slice",
+                cov[t0_idx],
+                dims=cov_dims[1:] if cov_dims is not None else None,
             )
 
             _ = LinearGaussianStateSpace(
@@ -1736,7 +1807,9 @@ class PyMCStateSpace:
         Q = None  # No covariance matrix needed if a trajectory is provided. Will be overwritten later if needed.
 
         if n_options > 1:
-            raise ValueError("Specify exactly 0 or 1 of shock_size, shock_cov, or shock_trajectory")
+            raise ValueError(
+                "Specify exactly 0 or 1 of shock_size, shock_cov, or shock_trajectory"
+            )
         elif n_options == 1:
             # If the user passed an alternative parameterization for the shocks of the IRF, don't use the posterior
             use_posterior_cov = False
@@ -1767,7 +1840,9 @@ class PyMCStateSpace:
             self._insert_random_variables()
 
             P0, _, c, d, T, Z, R, H, post_Q = self.unpack_statespace()
-            x0 = pm.Deterministic("x0_new", pt.zeros(self.k_states), dims=[ALL_STATE_DIM])
+            x0 = pm.Deterministic(
+                "x0_new", pt.zeros(self.k_states), dims=[ALL_STATE_DIM]
+            )
 
             if use_posterior_cov:
                 Q = post_Q
@@ -1781,7 +1856,9 @@ class PyMCStateSpace:
             if shock_trajectory is None:
                 shock_trajectory = pt.zeros((n_steps, self.k_posdef))
                 if Q is not None:
-                    init_shock = pm.MvNormal("initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM])
+                    init_shock = pm.MvNormal(
+                        "initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM]
+                    )
                 else:
                     init_shock = pm.Deterministic(
                         "initial_shock",

--- a/pymc_experimental/statespace/filters/kalman_smoother.py
+++ b/pymc_experimental/statespace/filters/kalman_smoother.py
@@ -65,7 +65,14 @@ class KalmanSmoother:
         return a, P, a_smooth, P_smooth, T, R, Q
 
     def build_graph(
-        self, T, R, Q, filtered_states, filtered_covariances, mode=None, cov_jitter=JITTER_DEFAULT
+        self,
+        T,
+        R,
+        Q,
+        filtered_states,
+        filtered_covariances,
+        mode=None,
+        cov_jitter=JITTER_DEFAULT,
     ):
         self.mode = mode
         self.cov_jitter = cov_jitter
@@ -75,8 +82,8 @@ class KalmanSmoother:
         a_last = pt.specify_shape(filtered_states[-1], (k,))
         P_last = pt.specify_shape(filtered_covariances[-1], (k, k))
 
-        sequences, non_sequences, seq_names, non_seq_names = split_vars_into_seq_and_nonseq(
-            [T, R, Q], ["T", "R", "Q"]
+        sequences, non_sequences, seq_names, non_seq_names = (
+            split_vars_into_seq_and_nonseq([T, R, Q], ["T", "R", "Q"])
         )
 
         self.seq_names = seq_names

--- a/pymc_experimental/statespace/models/VARMAX.py
+++ b/pymc_experimental/statespace/models/VARMAX.py
@@ -156,7 +156,9 @@ class BayesianVARMAX(PyMCStateSpace):
             endog_names = [f"state.{i + 1}" for i in range(k_endog)]
         if (endog_names is not None) and (k_endog is not None):
             if len(endog_names) != k_endog:
-                raise ValueError("Length of provided endog_names does not match provided k_endog")
+                raise ValueError(
+                    "Length of provided endog_names does not match provided k_endog"
+                )
 
         self.endog_names = list(endog_names)
         self.p, self.q = order
@@ -240,7 +242,9 @@ class BayesianVARMAX(PyMCStateSpace):
             f"L{i + 1}.{state}" for i in range(self.p - 1) for state in self.endog_names
         ]
         state_names += [
-            f"L{i + 1}.{state}_innov" for i in range(self.q) for state in self.endog_names
+            f"L{i + 1}.{state}_innov"
+            for i in range(self.q)
+            for state in self.endog_names
         ]
 
         return state_names
@@ -297,7 +301,9 @@ class BayesianVARMAX(PyMCStateSpace):
         # Initialize the matrices
         if not self.stationary_initialization:
             # initial states
-            x0 = self.make_and_register_variable("x0", shape=(self.k_states,), dtype=floatX)
+            x0 = self.make_and_register_variable(
+                "x0", shape=(self.k_states,), dtype=floatX
+            )
             self.ssm["initial_state", :] = x0
 
             # initial covariance
@@ -330,7 +336,11 @@ class BayesianVARMAX(PyMCStateSpace):
             self.ssm[("transition",) + idx] = np.eye(self.k_endog * (self.q - 1))
 
         if self.p > 0:
-            ar_param_idx = ("transition", slice(0, self.k_endog), slice(0, self.k_endog * self.p))
+            ar_param_idx = (
+                "transition",
+                slice(0, self.k_endog),
+                slice(0, self.k_endog * self.p),
+            )
 
             # Register the AR parameter matrix as a (k, p, k), then reshape it and allocate it in the transition matrix
             # This way the user can use 3 dimensions in the prior (clearer?)
@@ -361,7 +371,9 @@ class BayesianVARMAX(PyMCStateSpace):
             self.ssm[ma_param_idx] = ma_params
 
             end = -self.k_endog * (self.q - 1) if self.q > 1 else None
-            self.ssm["selection", slice(self.k_endog * -self.q, end), :] = np.eye(self.k_endog)
+            self.ssm["selection", slice(self.k_endog * -self.q, end), :] = np.eye(
+                self.k_endog
+            )
 
         if self.measurement_error:
             obs_cov_idx = ("obs_cov",) + np.diag_indices(self.k_endog)
@@ -382,7 +394,9 @@ class BayesianVARMAX(PyMCStateSpace):
             Q = self.ssm["state_cov"]
             c = self.ssm["state_intercept"]
 
-            x0 = pt.linalg.solve(pt.eye(T.shape[0]) - T, c, assume_a="gen", check_finite=False)
+            x0 = pt.linalg.solve(
+                pt.eye(T.shape[0]) - T, c, assume_a="gen", check_finite=False
+            )
             P0 = solve_discrete_lyapunov(
                 T,
                 pt.linalg.matrix_dot(R, Q, R.T),

--- a/pymc_experimental/statespace/models/utilities.py
+++ b/pymc_experimental/statespace/models/utilities.py
@@ -58,7 +58,9 @@ def cleanup_states(states: list[str]) -> list[str]:
     return out
 
 
-def make_harvey_state_names(p: int, d: int, q: int, P: int, D: int, Q: int, S: int) -> list[str]:
+def make_harvey_state_names(
+    p: int, d: int, q: int, P: int, D: int, Q: int, S: int
+) -> list[str]:
     """
     Generate informative names for the SARIMA states in the Harvey representation
 

--- a/pymc_experimental/statespace/utils/constants.py
+++ b/pymc_experimental/statespace/utils/constants.py
@@ -69,5 +69,13 @@ FILTER_OUTPUT_DIMS = {
     "predicted_observed_covariance": (TIME_DIM, OBS_STATE_DIM, OBS_STATE_AUX_DIM),
 }
 
-POSITION_DERIVATIVE_NAMES = ["level", "trend", "acceleration", "jerk", "snap", "crackle", "pop"]
+POSITION_DERIVATIVE_NAMES = [
+    "level",
+    "trend",
+    "acceleration",
+    "jerk",
+    "snap",
+    "crackle",
+    "pop",
+]
 SARIMAX_STATE_STRUCTURES = ["fast", "interpretable"]

--- a/pymc_experimental/statespace/utils/data_tools.py
+++ b/pymc_experimental/statespace/utils/data_tools.py
@@ -34,7 +34,9 @@ def get_data_dims(data):
     return data_dims
 
 
-def _validate_data_shape(data_shape, n_obs, obs_coords=None, check_col_names=False, col_names=None):
+def _validate_data_shape(
+    data_shape, n_obs, obs_coords=None, check_col_names=False, col_names=None
+):
     if col_names is None:
         col_names = []
 
@@ -150,7 +152,7 @@ def mask_missing_values_in_data(values, missing_fill_value=None):
             )
 
         impute_message = (
-            f"Provided data contains missing values and"
+            "Provided data contains missing values and"
             " will be automatically imputed as hidden states"
             " during Kalman filtering."
         )
@@ -170,7 +172,9 @@ def register_data_with_pymc(
     elif isinstance(data, (pd.DataFrame, pd.Series)):
         values, index = preprocess_pandas_data(data, n_obs, obs_coords)
     else:
-        raise ValueError("Data should be one of pytensor tensor, numpy array, or pandas dataframe")
+        raise ValueError(
+            "Data should be one of pytensor tensor, numpy array, or pandas dataframe"
+        )
 
     data, nan_mask = mask_missing_values_in_data(values, missing_fill_value)
 

--- a/pymc_experimental/utils/pivoted_cholesky.py
+++ b/pymc_experimental/utils/pivoted_cholesky.py
@@ -6,7 +6,9 @@ except ImportError as e:
 
 import numpy as np
 
-pp = lambda x: np.array2string(x, precision=4, floatmode="fixed")
+
+def pp(x):
+    return np.array2string(x, precision=4, floatmode="fixed")
 
 
 def pivoted_cholesky(mat: np.matrix, error_tol=1e-6, max_iter=np.inf):

--- a/pymc_experimental/utils/prior.py
+++ b/pymc_experimental/utils/prior.py
@@ -44,7 +44,9 @@ class FlatInfo(TypedDict):
     info: List[VarInfo]
 
 
-def _arg_to_param_cfg(key, value: Optional[Union[ParamCfg, Transform, str, Tuple]] = None):
+def _arg_to_param_cfg(
+    key, value: Optional[Union[ParamCfg, Transform, str, Tuple]] = None
+):
     if value is None:
         cfg = ParamCfg(name=key, transform=None, dims=None)
     elif isinstance(value, Tuple):
@@ -133,7 +135,7 @@ def prior_from_idata(
     name="trace_prior_",
     *,
     var_names: Sequence[str] = (),
-    **kwargs: Union[ParamCfg, Transform, str, Tuple]
+    **kwargs: Union[ParamCfg, Transform, str, Tuple],
 ) -> Dict[str, pt.TensorVariable]:
     """
     Create a prior from posterior using MvNormal approximation.

--- a/pymc_experimental/utils/spline.py
+++ b/pymc_experimental/utils/spline.py
@@ -41,11 +41,13 @@ class BSplineBasis(Op):
 
     def make_node(self, *inputs) -> Apply:
         eval_points, k, d = map(pt.as_tensor, inputs)
-        if not (eval_points.ndim == 1 and np.issubdtype(eval_points.dtype, np.floating)):
+        if not (
+            eval_points.ndim == 1 and np.issubdtype(eval_points.dtype, np.floating)
+        ):
             raise TypeError("eval_points should be a vector of floats")
-        if not k.type in pt.int_types:
+        if k.type not in pt.int_types:
             raise TypeError("k should be integer")
-        if not d.type in pt.int_types:
+        if d.type not in pt.int_types:
             raise TypeError("degree should be integer")
         if self.sparse:
             out_type = ps.SparseTensorType("csr", eval_points.dtype)()

--- a/pymc_experimental/version.py
+++ b/pymc_experimental/version.py
@@ -2,7 +2,9 @@ import os
 
 
 def get_version():
-    version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "version.txt")
+    version_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "version.txt"
+    )
     with open(version_file) as f:
         version = f.read().strip()
     return version

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import itertools
+import os
 from codecs import open
 from os.path import dirname, join, realpath
 
@@ -60,12 +61,10 @@ extras_require = dict(
     dask_histogram=["dask[complete]", "xhistogram"],
     histogram=["xhistogram"],
 )
-extras_require["complete"] = sorted(set(itertools.chain.from_iterable(extras_require.values())))
+extras_require["complete"] = sorted(
+    set(itertools.chain.from_iterable(extras_require.values()))
+)
 extras_require["dev"] = dev_install_reqs
-
-import os
-
-from setuptools import find_packages, setup
 
 
 def read_version():

--- a/setupegg.py
+++ b/setupegg.py
@@ -17,7 +17,5 @@
 A setup.py script to use setuptools, which gives egg goodness, etc.
 """
 
-from setuptools import setup
-
 with open("setup.py") as s:
     exec(s.read())

--- a/tests/distributions/__init__.py
+++ b/tests/distributions/__init__.py
@@ -15,3 +15,5 @@
 
 from pymc_experimental.distributions import histogram_utils
 from pymc_experimental.distributions.histogram_utils import histogram_approximation
+
+__all__ = ["histogram_utils", "histogram_approximation"]

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -85,7 +85,13 @@ class TestGenExtremeClass:
         "mu, sigma, xi, size, expected",
         [
             (0, 1, 0, None, 0),
-            (1, np.arange(1, 4), 0.1, None, 1 + np.arange(1, 4) * (1.1**-0.1 - 1) / 0.1),
+            (
+                1,
+                np.arange(1, 4),
+                0.1,
+                None,
+                1 + np.arange(1, 4) * (1.1**-0.1 - 1) / 0.1,
+            ),
             (np.arange(5), 1, 0.1, None, np.arange(5) + (1.1**-0.1 - 1) / 0.1),
             (
                 0,
@@ -105,7 +111,10 @@ class TestGenExtremeClass:
                     (3, 6),
                     np.arange(6)
                     + np.arange(1, 7)
-                    * ((1 + np.linspace(-0.2, 0.2, 6)) ** -np.linspace(-0.2, 0.2, 6) - 1)
+                    * (
+                        (1 + np.linspace(-0.2, 0.2, 6)) ** -np.linspace(-0.2, 0.2, 6)
+                        - 1
+                    )
                     / np.linspace(-0.2, 0.2, 6),
                 ),
             ),

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -104,14 +104,18 @@ class TestGeneralizedPoisson:
         mu = 30
         lam = np.array([-0.9, -0.7, -0.2, 0, 0.2, 0.7, 0.9])
         with pm.Model():
-            x = GeneralizedPoisson("x", mu=mu, lam=lam)
+            GeneralizedPoisson("x", mu=mu, lam=lam)
             trace = pm.sample(chains=1, draws=10_000, random_seed=96).posterior
 
         expected_mean = mu / (1 - lam)
-        np.testing.assert_allclose(trace["x"].mean(("chain", "draw")), expected_mean, rtol=1e-1)
+        np.testing.assert_allclose(
+            trace["x"].mean(("chain", "draw")), expected_mean, rtol=1e-1
+        )
 
         expected_std = np.sqrt(mu / (1 - lam) ** 3)
-        np.testing.assert_allclose(trace["x"].std(("chain", "draw")), expected_std, rtol=1e-1)
+        np.testing.assert_allclose(
+            trace["x"].std(("chain", "draw")), expected_std, rtol=1e-1
+        )
 
     @pytest.mark.parametrize(
         "mu, lam, size, expected",

--- a/tests/distributions/test_discrete_markov_chain.py
+++ b/tests/distributions/test_discrete_markov_chain.py
@@ -23,10 +23,15 @@ def transition_probability_tests(steps, n_states, n_lags, n_draws, atol):
     # Test x0 is uniform over n_states
     for i in range(n_lags):
         assert np.allclose(
-            np.histogram(draws[:, ..., i], bins=n_states)[0] / n_draws, 1 / n_states, atol=atol
+            np.histogram(draws[:, ..., i], bins=n_states)[0] / n_draws,
+            1 / n_states,
+            atol=atol,
         )
 
-    n_grams = [[tuple(row[i : i + n_lags + 1]) for i in range(len(row) - n_lags)] for row in draws]
+    n_grams = [
+        [tuple(row[i : i + n_lags + 1]) for i in range(len(row) - n_lags)]
+        for row in draws
+    ]
     freq_table = np.zeros((n_states,) * (n_lags + 1))
 
     for row in n_grams:
@@ -60,16 +65,20 @@ class TestDiscreteMarkovRV:
         x0 = pm.Categorical.dist(p=np.ones(3) / 3)
         chain = DiscreteMarkovChain.dist(P=P, steps=10, init_dist=x0, n_lags=n_lags)
         draws = pm.draw(chain, 10)
-        logp = pm.logp(chain, draws)
+        pm.logp(chain, draws)
 
     def test_default_init_dist_warns_user(self):
-        P = pt.as_tensor_variable(np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]]))
+        P = pt.as_tensor_variable(
+            np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
+        )
 
         with pytest.warns(UserWarning):
             DiscreteMarkovChain.dist(P=P, steps=3)
 
     def test_logp_shape(self):
-        P = pt.as_tensor_variable(np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]]))
+        P = pt.as_tensor_variable(
+            np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
+        )
         x0 = pm.Categorical.dist(p=np.ones(3) / 3)
 
         # Test with steps
@@ -87,7 +96,9 @@ class TestDiscreteMarkovRV:
         assert logp.shape == (5,)
 
     def test_logp_with_default_init_dist(self):
-        P = pt.as_tensor_variable(np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]]))
+        P = pt.as_tensor_variable(
+            np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
+        )
         x0 = pm.Categorical.dist(p=np.ones(3) / 3)
 
         value = np.array([0, 1, 2])
@@ -105,7 +116,9 @@ class TestDiscreteMarkovRV:
         np.testing.assert_allclose(model_logp_eval, logp_expected, rtol=1e-6)
 
     def test_logp_with_user_defined_init_dist(self):
-        P = pt.as_tensor_variable(np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]]))
+        P = pt.as_tensor_variable(
+            np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
+        )
         x0 = pm.Categorical.dist(p=[0.2, 0.6, 0.2])
         chain = DiscreteMarkovChain.dist(P=P, init_dist=x0, steps=3)
 
@@ -161,7 +174,9 @@ class TestDiscreteMarkovRV:
             P = pt.full((3, 3), 1 / 3)
             x0 = pm.Categorical.dist(p=np.ones(3) / 3)
 
-            chain = DiscreteMarkovChain("chain", P=P, steps=3, init_dist=x0, dims=["steps"])
+            chain = DiscreteMarkovChain(
+                "chain", P=P, steps=3, init_dist=x0, dims=["steps"]
+            )
 
         assert chain.eval().shape == (4,)
 
@@ -196,16 +211,24 @@ class TestDiscreteMarkovRV:
             x0 = pm.Categorical.dist(p=[0.1, 0.1, 0.8], size=2)
             data = pm.draw(x0, 100)
 
-            chain = DiscreteMarkovChain("chain", P=P, init_dist=x0, n_lags=2, observed=data)
+            chain = DiscreteMarkovChain(
+                "chain", P=P, init_dist=x0, n_lags=2, observed=data
+            )
 
         assert chain.eval().shape == (100, 2)
 
     def test_random_draws(self):
-        transition_probability_tests(steps=3, n_states=2, n_lags=1, n_draws=2500, atol=0.05)
-        transition_probability_tests(steps=3, n_states=2, n_lags=3, n_draws=7500, atol=0.05)
+        transition_probability_tests(
+            steps=3, n_states=2, n_lags=1, n_draws=2500, atol=0.05
+        )
+        transition_probability_tests(
+            steps=3, n_states=2, n_lags=3, n_draws=7500, atol=0.05
+        )
 
     def test_change_size_univariate(self):
-        P = pt.as_tensor_variable(np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]]))
+        P = pt.as_tensor_variable(
+            np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
+        )
         x0 = pm.Categorical.dist(p=np.ones(3) / 3)
 
         chain = DiscreteMarkovChain.dist(P=P, init_dist=x0, shape=(100, 5))

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -9,7 +9,9 @@ import pymc_experimental as pmx
 class TestR2D2M2CP:
     @pytest.fixture(autouse=True)
     def fast_compile(self):
-        with pytensor.config.change_flags(mode="FAST_COMPILE", exception_verbosity="high"):
+        with pytensor.config.change_flags(
+            mode="FAST_COMPILE", exception_verbosity="high"
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -123,7 +125,9 @@ class TestR2D2M2CP:
         assert beta.eval().shape == input_std.shape
         # r2 rv is only created if r2 std is not None
         assert "beta" in model.named_vars
-        assert ("beta::r2" in model.named_vars) == (r2_std is not None), set(model.named_vars)
+        assert ("beta::r2" in model.named_vars) == (r2_std is not None), set(
+            model.named_vars
+        )
         # phi is only created if variable importance is not None and there is more than one var
         assert np.isfinite(model.compile_logp()(model.initial_point()))
 
@@ -221,11 +225,18 @@ class TestR2D2M2CP:
                 )
         else:
             pmx.distributions.R2D2M2CP(
-                "beta", output_std, input_std, dims=dims, r2=0.8, variance_explained=abs(input_std)
+                "beta",
+                output_std,
+                input_std,
+                dims=dims,
+                r2=0.8,
+                variance_explained=abs(input_std),
             )
 
     def test_failing_mutual_exclusive(self, model: pm.Model):
-        with pytest.raises(TypeError, match="variable importance with variance explained"):
+        with pytest.raises(
+            TypeError, match="variable importance with variance explained"
+        ):
             with model:
                 model.add_coord("a", range(2))
             pmx.distributions.R2D2M2CP(
@@ -295,10 +306,18 @@ class TestR2D2M2CP:
     def test_zero_length_rvs_not_created(self, model: pm.Model):
         model.add_coord("a", range(2))
         # deterministic case which should not have any new variables
-        b = pmx.distributions.R2D2M2CP("b1", 1, [1, 1], r2=0.5, positive_probs=[1, 1], dims="a")
+        pmx.distributions.R2D2M2CP(
+            "b1", 1, [1, 1], r2=0.5, positive_probs=[1, 1], dims="a"
+        )
         assert not model.free_RVs, model.free_RVs
 
-        b = pmx.distributions.R2D2M2CP(
-            "b2", 1, [1, 1], r2=0.5, positive_probs=[1, 1], positive_probs_std=[0, 0], dims="a"
+        pmx.distributions.R2D2M2CP(
+            "b2",
+            1,
+            [1, 1],
+            r2=0.5,
+            positive_probs=[1, 1],
+            positive_probs_std=[0, 0],
+            dims="a",
         )
         assert not model.free_RVs, model.free_RVs

--- a/tests/model/transforms/test_autoreparam.py
+++ b/tests/model/transforms/test_autoreparam.py
@@ -78,12 +78,18 @@ def test_multilevel():
         s = pm.HalfNormal("s")
         a_g = pm.Normal("a_g", a, s, shape=(2,), dims="level")
         s_g = pm.HalfNormal("s_g")
-        a_ig = pm.Normal("a_ig", a_g, s_g, shape=(2, 2), dims=("county", "level"))
+        pm.Normal("a_ig", a_g, s_g, shape=(2, 2), dims=("county", "level"))
 
     model_r, vip = vip_reparametrize(model, ["a_g", "a_ig"])
     assert "a_g" in vip.get_lambda()
     assert "a_ig" in vip.get_lambda()
-    assert {v.name for v in model_r.free_RVs} == {"a", "s", "a_g::tau_", "s_g", "a_ig::tau_"}
+    assert {v.name for v in model_r.free_RVs} == {
+        "a",
+        "s",
+        "a_g::tau_",
+        "s_g",
+        "a_ig::tau_",
+    }
     assert "a_g" in [v.name for v in model_r.deterministics]
 
 

--- a/tests/statespace/test_coord_assignment.py
+++ b/tests/statespace/test_coord_assignment.py
@@ -20,7 +20,13 @@ from pymc_experimental.statespace.utils.data_tools import (
 )
 from tests.statespace.utilities.test_helpers import load_nile_test_data
 
-function_names = ["pandas_date_freq", "pandas_date_nofreq", "pandas_nodate", "numpy", "pytensor"]
+function_names = [
+    "pandas_date_freq",
+    "pandas_date_nofreq",
+    "pandas_nodate",
+    "numpy",
+    "pytensor",
+]
 expected_warning = [
     does_not_raise(),
     pytest.warns(UserWarning, match=NO_FREQ_INFO_WARNING),
@@ -78,10 +84,12 @@ def create_model(load_dataset):
                 1,
                 dims="state",
             )
-            P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=("state", "state_aux"))
-            initial_trend = pm.Normal("initial_trend", dims="trend_state")
-            sigma_trend = pm.Exponential("sigma_trend", 1, dims="trend_shock")
-            ss_mod.build_statespace_graph(data, save_kalman_filter_outputs_in_idata=True)
+            pm.Deterministic("P0", pt.diag(P0_diag), dims=("state", "state_aux"))
+            pm.Normal("initial_trend", dims="trend_state")
+            pm.Exponential("sigma_trend", 1, dims="trend_shock")
+            ss_mod.build_statespace_graph(
+                data, save_kalman_filter_outputs_in_idata=True
+            )
         return mod
 
     return _create_model
@@ -92,7 +100,9 @@ def test_filter_output_coord_assignment(f, warning, create_model):
     with warning:
         pymc_model = create_model(f)
 
-    for output in FILTER_OUTPUT_NAMES + SMOOTHER_OUTPUT_NAMES + ["predicted_observed_state"]:
+    for output in (
+        FILTER_OUTPUT_NAMES + SMOOTHER_OUTPUT_NAMES + ["predicted_observed_state"]
+    ):
         assert pymc_model.named_vars_to_dims[output] == FILTER_OUTPUT_DIMS[output]
 
 
@@ -101,9 +111,9 @@ def test_model_build_without_coords(load_dataset):
     data = load_dataset("numpy")
     with pm.Model() as mod:
         P0_diag = pm.Exponential("P0_diag", 1, shape=(2,))
-        P0 = pm.Deterministic("P0", pt.diag(P0_diag))
-        initial_trend = pm.Normal("initial_trend", shape=(2,))
-        sigma_trend = pm.Exponential("sigma_trend", 1, shape=(2,))
+        pm.Deterministic("P0", pt.diag(P0_diag))
+        pm.Normal("initial_trend", shape=(2,))
+        pm.Exponential("sigma_trend", 1, shape=(2,))
         ss_mod.build_statespace_graph(data, register_data=False)
 
     assert mod.coords == {}

--- a/tests/statespace/test_kalman_filter.py
+++ b/tests/statespace/test_kalman_filter.py
@@ -137,7 +137,9 @@ def f_standard_nd():
         ll_obs,
     ) = StandardFilter().build_graph(*inputs)
 
-    smoothed_states, smoothed_covs = ksmoother.build_graph(T, R, Q, filtered_states, filtered_covs)
+    smoothed_states, smoothed_covs = ksmoother.build_graph(
+        T, R, Q, filtered_states, filtered_covs
+    )
 
     outputs = [
         filtered_states,
@@ -234,7 +236,9 @@ def test_missing_data(filter_func, filter_name, p, rng):
 
 
 @pytest.mark.parametrize("filter_func", filter_funcs, ids=filter_names)
-@pytest.mark.parametrize("output_idx", [(0, 2), (3, 5)], ids=["smoothed_states", "smoothed_covs"])
+@pytest.mark.parametrize(
+    "output_idx", [(0, 2), (3, 5)], ids=["smoothed_states", "smoothed_covs"]
+)
 def test_last_smoother_is_last_filtered(filter_func, output_idx, rng):
     p, m, r, n = 1, 5, 1, 10
     inputs = make_test_inputs(p, m, r, n, rng)
@@ -288,16 +292,24 @@ def test_filters_match_statsmodel_output(filter_func, n_missing, rng):
 
 
 @pytest.mark.parametrize(
-    "filter_func, filter_name", zip(filter_funcs[:-1], filter_names[:-1]), ids=filter_names[:-1]
+    "filter_func, filter_name",
+    zip(filter_funcs[:-1], filter_names[:-1]),
+    ids=filter_names[:-1],
 )
 @pytest.mark.parametrize("n_missing", [0, 5], ids=["n_missing=0", "n_missing=5"])
 @pytest.mark.parametrize("obs_noise", [True, False])
-def test_all_covariance_matrices_are_PSD(filter_func, filter_name, n_missing, obs_noise, rng):
+def test_all_covariance_matrices_are_PSD(
+    filter_func, filter_name, n_missing, obs_noise, rng
+):
     if (floatX == "float32") & (filter_name == "UnivariateFilter"):
         # TODO: These tests all pass locally for me with float32 but they fail on the CI, so i'm just disabling them.
-        pytest.skip("Univariate filter not stable at half precision without measurement error")
+        pytest.skip(
+            "Univariate filter not stable at half precision without measurement error"
+        )
 
-    fit_sm_mod, [data, a0, P0, c, d, T, Z, R, H, Q] = nile_test_test_helper(rng, n_missing)
+    fit_sm_mod, [data, a0, P0, c, d, T, Z, R, H, Q] = nile_test_test_helper(
+        rng, n_missing
+    )
 
     H *= int(obs_noise)
     inputs = [data, a0, P0, c, d, T, Z, R, H, Q]
@@ -307,7 +319,9 @@ def test_all_covariance_matrices_are_PSD(filter_func, filter_name, n_missing, ob
         cov_stack = outputs[output_idx]
         w, v = np.linalg.eig(cov_stack)
 
-        assert_array_less(0, w, err_msg=f"Smallest eigenvalue of {name}: {min(w.ravel())}")
+        assert_array_less(
+            0, w, err_msg=f"Smallest eigenvalue of {name}: {min(w.ravel())}"
+        )
         assert_allclose(
             cov_stack,
             np.swapaxes(cov_stack, -2, -1),
@@ -348,4 +362,6 @@ def test_kalman_filter_jax(filter):
     pt_outputs = f_pt(*inputs_np)
 
     for name, jax_res, pt_res in zip(output_names, jax_outputs, pt_outputs):
-        assert_allclose(jax_res, pt_res, atol=ATOL, rtol=RTOL, err_msg=f"{name} failed!")
+        assert_allclose(
+            jax_res, pt_res, atol=ATOL, rtol=RTOL, err_msg=f"{name} failed!"
+        )

--- a/tests/statespace/test_representation.py
+++ b/tests/statespace/test_representation.py
@@ -123,28 +123,34 @@ class BasicFunctionality(unittest.TestCase):
         assert_allclose(fast_eval(ssm["design"][0, 0]), 3.0, atol=atol)
         assert_allclose(fast_eval(ssm["transition"][0, :]), 2.7, atol=atol)
         assert_allclose(fast_eval(ssm["selection"][-1, -1]), 9.9, atol=atol)
-        assert_allclose(fast_eval(ssm["state_intercept"][:, 0]), np.arange(n), atol=atol)
+        assert_allclose(
+            fast_eval(ssm["state_intercept"][:, 0]), np.arange(n), atol=atol
+        )
 
     def test_invalid_key_name_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
         with self.assertRaises(IndexError) as e:
-            X = ssm["invalid_key"]
+            ssm["invalid_key"]
         msg = str(e.exception)
         self.assertEqual(msg, "invalid_key is an invalid state space matrix name")
 
     def test_non_string_key_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
         with self.assertRaises(IndexError) as e:
-            X = ssm[0]
+            ssm[0]
         msg = str(e.exception)
-        self.assertEqual(msg, "First index must the name of a valid state space matrix.")
+        self.assertEqual(
+            msg, "First index must the name of a valid state space matrix."
+        )
 
     def test_invalid_key_tuple_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
         with self.assertRaises(IndexError) as e:
-            X = ssm[0, 1, 1]
+            ssm[0, 1, 1]
         msg = str(e.exception)
-        self.assertEqual(msg, "First index must the name of a valid state space matrix.")
+        self.assertEqual(
+            msg, "First index must the name of a valid state space matrix."
+        )
 
     def test_slice_statespace_matrix(self):
         T = np.eye(5)

--- a/tests/statespace/test_structural.py
+++ b/tests/statespace/test_structural.py
@@ -24,9 +24,6 @@ from pymc_experimental.statespace.utils.constants import (
     SHOCK_DIM,
     SHORT_NAME_TO_LONG,
 )
-from tests.statespace.utilities.shared_fixtures import (  # pylint: disable=unused-import
-    rng,
-)
 from tests.statespace.utilities.test_helpers import (
     assert_pattern_repeats,
     simulate_from_numpy_model,
@@ -82,7 +79,9 @@ def _assert_coord_shapes_match_matrices(mod, params):
     assert c.shape[-1:] == (
         n_states,
     ), f"c expected to have shape (n_states, ), found {c.shape[-1:]}"
-    assert d.shape[-1:] == (n_obs,), f"d expected to have shape (n_obs, ), found {d.shape[-1:]}"
+    assert d.shape[-1:] == (
+        n_obs,
+    ), f"d expected to have shape (n_obs, ), found {d.shape[-1:]}"
     assert T.shape[-2:] == (
         n_states,
         n_states,
@@ -118,7 +117,9 @@ def _assert_keys_match(test_dict, expected_dict):
     expected_keys = list(expected_dict.keys())
     param_keys = list(test_dict.keys())
     key_diff = set(expected_keys) - set(param_keys)
-    assert len(key_diff) == 0, f'{", ".join(key_diff)} were not found in the test_dict keys.'
+    assert (
+        len(key_diff) == 0
+    ), f'{", ".join(key_diff)} were not found in the test_dict keys.'
 
     key_diff = set(param_keys) - set(expected_keys)
     assert (
@@ -300,10 +301,12 @@ def create_structural_model_and_equivalent_statsmodel(
             sm_params["sigma2.level"] = sigma
         if stochastic_trend:
             sigma = sigma_level_value.pop(0)
-            sm_params[f"sigma2.trend"] = sigma
+            sm_params["sigma2.trend"] = sigma
 
         comp = st.LevelTrendComponent(
-            name="level", order=level_trend_order, innovations_order=level_trend_innov_order
+            name="level",
+            order=level_trend_order,
+            innovations_order=level_trend_innov_order,
         )
         components.append(comp)
 
@@ -318,7 +321,8 @@ def create_structural_model_and_equivalent_statsmodel(
         expected_coords[ALL_STATE_AUX_DIM] += state_names
 
         seasonal_dict = {
-            "seasonal" if i == 0 else f"seasonal.L{i}": c for i, c in enumerate(seasonal_coefs)
+            "seasonal" if i == 0 else f"seasonal.L{i}": c
+            for i, c in enumerate(seasonal_coefs)
         }
         sm_init.update(seasonal_dict)
 
@@ -345,7 +349,9 @@ def create_structural_model_and_equivalent_statsmodel(
             s = d["period"]
             last_state_not_identified = (s / n) == 2.0
             n_states = 2 * n - int(last_state_not_identified)
-            state_names = [f"seasonal_{s}_{f}_{i}" for i in range(n) for f in ["Cos", "Sin"]]
+            state_names = [
+                f"seasonal_{s}_{f}_{i}" for i in range(n) for f in ["Cos", "Sin"]
+            ]
 
             seasonal_params = rng.normal(size=n_states).astype(floatX)
 
@@ -354,7 +360,9 @@ def create_structural_model_and_equivalent_statsmodel(
             expected_coords[ALL_STATE_DIM] += state_names
             expected_coords[ALL_STATE_AUX_DIM] += state_names
             expected_coords[f"seasonal_{s}_state"] += (
-                tuple(state_names[:-1]) if last_state_not_identified else tuple(state_names)
+                tuple(state_names[:-1])
+                if last_state_not_identified
+                else tuple(state_names)
             )
 
             for param in seasonal_params:
@@ -472,7 +480,9 @@ def create_structural_model_and_equivalent_statsmodel(
     ],
 )
 @pytest.mark.parametrize("autoregressive", [None, 3])
-@pytest.mark.parametrize("seasonal, stochastic_seasonal", [(None, False), (12, False), (12, True)])
+@pytest.mark.parametrize(
+    "seasonal, stochastic_seasonal", [(None, False), (12, False), (12, True)]
+)
 @pytest.mark.parametrize(
     "freq_seasonal, stochastic_freq_seasonal",
     [
@@ -485,8 +495,12 @@ def create_structural_model_and_equivalent_statsmodel(
     "cycle, damped_cycle, stochastic_cycle",
     [(False, False, False), (True, False, True), (True, True, True)],
 )
-@pytest.mark.filterwarnings("ignore::statsmodels.tools.sm_exceptions.ConvergenceWarning")
-@pytest.mark.filterwarnings("ignore::statsmodels.tools.sm_exceptions.SpecificationWarning")
+@pytest.mark.filterwarnings(
+    "ignore::statsmodels.tools.sm_exceptions.ConvergenceWarning"
+)
+@pytest.mark.filterwarnings(
+    "ignore::statsmodels.tools.sm_exceptions.SpecificationWarning"
+)
 def test_structural_model_against_statsmodels(
     level,
     trend,
@@ -526,7 +540,11 @@ def test_structural_model_against_statsmodels(
 
     if len(sm_init) > 0:
         init_array = np.concatenate(
-            [np.atleast_1d(sm_init[k]).ravel() for k in sm_mod.state_names if k != "dummy"]
+            [
+                np.atleast_1d(sm_init[k]).ravel()
+                for k in sm_mod.state_names
+                if k != "dummy"
+            ]
         )
         sm_mod.initialize_known(init_array, np.eye(sm_mod.k_states))
     else:
@@ -545,7 +563,9 @@ def test_structural_model_against_statsmodels(
     _assert_coord_shapes_match_matrices(built_model, params)
     _assert_param_dims_correct(built_model.param_dims, expected_dims)
     _assert_coords_correct(built_model.coords, expected_coords)
-    _assert_params_info_correct(built_model.param_info, built_model.coords, built_model.param_dims)
+    _assert_params_info_correct(
+        built_model.param_info, built_model.coords, built_model.param_dims
+    )
 
 
 def test_level_trend_model(rng):
@@ -664,9 +684,16 @@ def test_cycle_component_deterministic(rng):
 
 def test_cycle_component_with_dampening(rng):
     cycle = st.CycleComponent(
-        name="cycle", cycle_length=12, estimate_cycle_length=False, innovations=False, dampen=True
+        name="cycle",
+        cycle_length=12,
+        estimate_cycle_length=False,
+        innovations=False,
+        dampen=True,
     )
-    params = {"cycle": np.array([10.0, 10.0], dtype=floatX), "cycle_dampening_factor": 0.75}
+    params = {
+        "cycle": np.array([10.0, 10.0], dtype=floatX),
+        "cycle_dampening_factor": 0.75,
+    }
     x, y = simulate_from_numpy_model(cycle, rng, params, steps=100)
 
     # Check that the cycle dampens to zero over time
@@ -734,15 +761,21 @@ def test_add_components():
     all_params = ll_params.copy()
     all_params.update(se_params)
 
-    (ll_x0, ll_P0, ll_c, ll_d, ll_T, ll_Z, ll_R, ll_H, ll_Q) = unpack_symbolic_matrices_with_params(
-        ll, ll_params
+    (ll_x0, ll_P0, ll_c, ll_d, ll_T, ll_Z, ll_R, ll_H, ll_Q) = (
+        unpack_symbolic_matrices_with_params(ll, ll_params)
     )
-    (se_x0, se_P0, se_c, se_d, se_T, se_Z, se_R, se_H, se_Q) = unpack_symbolic_matrices_with_params(
-        se, se_params
+    (se_x0, se_P0, se_c, se_d, se_T, se_Z, se_R, se_H, se_Q) = (
+        unpack_symbolic_matrices_with_params(se, se_params)
     )
     x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(mod, all_params)
 
-    for property in ["param_names", "shock_names", "param_info", "coords", "param_dims"]:
+    for property in [
+        "param_names",
+        "shock_names",
+        "param_info",
+        "coords",
+        "param_dims",
+    ]:
         assert [x in getattr(mod, property) for x in getattr(ll, property)]
         assert [x in getattr(mod, property) for x in getattr(se, property)]
 
@@ -751,7 +784,9 @@ def test_add_components():
     all_mats = [T, R, Q]
 
     for ll_mat, se_mat, all_mat in zip(ll_mats, se_mats, all_mats):
-        assert_allclose(all_mat, linalg.block_diag(ll_mat, se_mat), atol=ATOL, rtol=RTOL)
+        assert_allclose(
+            all_mat, linalg.block_diag(ll_mat, se_mat), atol=ATOL, rtol=RTOL
+        )
 
     ll_mats = [ll_x0, ll_c, ll_Z]
     se_mats = [se_x0, se_c, se_Z]
@@ -759,7 +794,9 @@ def test_add_components():
     axes = [0, 0, 1]
 
     for ll_mat, se_mat, all_mat, axis in zip(ll_mats, se_mats, all_mats, axes):
-        assert_allclose(all_mat, np.concatenate([ll_mat, se_mat], axis=axis), atol=ATOL, rtol=RTOL)
+        assert_allclose(
+            all_mat, np.concatenate([ll_mat, se_mat], axis=axis), atol=ATOL, rtol=RTOL
+        )
 
 
 def test_filter_scans_time_varying_design_matrix(rng):
@@ -771,12 +808,12 @@ def test_filter_scans_time_varying_design_matrix(rng):
     reg = st.RegressionComponent(state_names=["a", "b"], name="exog")
     mod = reg.build(verbose=False)
 
-    with pm.Model(coords=mod.coords) as m:
-        data_exog = pm.Data("data_exog", data.values)
+    with pm.Model(coords=mod.coords):
+        pm.Data("data_exog", data.values)
 
         x0 = pm.Normal("x0", dims=["state"])
         P0 = pm.Deterministic("P0", pt.eye(mod.k_states), dims=["state", "state_aux"])
-        beta_exog = pm.Normal("beta_exog", dims=["exog_state"])
+        pm.Normal("beta_exog", dims=["exog_state"])
 
         mod.build_statespace_graph(y)
         x0, P0, c, d, T, Z, R, H, Q = mod.unpack_statespace()
@@ -789,7 +826,9 @@ def test_filter_scans_time_varying_design_matrix(rng):
     assert_allclose(prior_Z[0, :, :, 0, :], data.values[None].repeat(10, axis=0))
 
 
-@pytest.mark.skipif(floatX.endswith("32"), reason="Prior covariance not PSD at half-precision")
+@pytest.mark.skipif(
+    floatX.endswith("32"), reason="Prior covariance not PSD at half-precision"
+)
 def test_extract_components_from_idata(rng):
     time_idx = pd.date_range(start="2000-01-01", freq="D", periods=100)
     data = pd.DataFrame(rng.normal(size=(100, 2)), columns=["a", "b"], index=time_idx)
@@ -797,21 +836,23 @@ def test_extract_components_from_idata(rng):
     y = pd.DataFrame(rng.normal(size=(100, 1)), columns=["data"], index=time_idx)
 
     ll = st.LevelTrendComponent()
-    season = st.FrequencySeasonality(name="seasonal", season_length=12, n=2, innovations=False)
+    season = st.FrequencySeasonality(
+        name="seasonal", season_length=12, n=2, innovations=False
+    )
     reg = st.RegressionComponent(state_names=["a", "b"], name="exog")
     me = st.MeasurementError("obs")
     mod = (ll + season + reg + me).build(verbose=False)
 
-    with pm.Model(coords=mod.coords) as m:
-        data_exog = pm.Data("data_exog", data.values)
+    with pm.Model(coords=mod.coords):
+        pm.Data("data_exog", data.values)
 
         x0 = pm.Normal("x0", dims=["state"])
         P0 = pm.Deterministic("P0", pt.eye(mod.k_states), dims=["state", "state_aux"])
-        beta_exog = pm.Normal("beta_exog", dims=["exog_state"])
-        initial_trend = pm.Normal("initial_trend", dims=["trend_state"])
-        sigma_trend = pm.Exponential("sigma_trend", 1, dims=["trend_shock"])
-        seasonal_coefs = pm.Normal("seasonal", dims=["seasonal_state"])
-        sigma_obs = pm.Exponential("sigma_obs", 1)
+        pm.Normal("beta_exog", dims=["exog_state"])
+        pm.Normal("initial_trend", dims=["trend_state"])
+        pm.Exponential("sigma_trend", 1, dims=["trend_shock"])
+        pm.Normal("seasonal", dims=["seasonal_state"])
+        pm.Exponential("sigma_obs", 1)
 
         mod.build_statespace_graph(y)
 
@@ -821,7 +862,13 @@ def test_extract_components_from_idata(rng):
     filter_prior = mod.sample_conditional_prior(prior)
     comp_prior = mod.extract_components_from_idata(filter_prior)
     comp_states = comp_prior.filtered_prior.coords["state"].values
-    expected_states = ["LevelTrend[level]", "LevelTrend[trend]", "seasonal", "exog[a]", "exog[b]"]
+    expected_states = [
+        "LevelTrend[level]",
+        "LevelTrend[trend]",
+        "seasonal",
+        "exog[a]",
+        "exog[b]",
+    ]
     missing = set(comp_states) - set(expected_states)
 
     assert len(missing) == 0, missing

--- a/tests/statespace/utilities/test_helpers.py
+++ b/tests/statespace/utilities/test_helpers.py
@@ -58,7 +58,9 @@ def initialize_filter(kfilter, mode=None):
         ll_obs,
     ) = kfilter.build_graph(*inputs, mode=mode)
 
-    smoothed_states, smoothed_covs = ksmoother.build_graph(T, R, Q, filtered_states, filtered_covs)
+    smoothed_states, smoothed_covs = ksmoother.build_graph(
+        T, R, Q, filtered_states, filtered_covs
+    )
 
     outputs = [
         filtered_states,
@@ -210,7 +212,9 @@ def unpack_statespace(ssm):
     return [ssm[SHORT_NAME_TO_LONG[x]] for x in MATRIX_NAMES]
 
 
-def unpack_symbolic_matrices_with_params(mod, param_dict, data_dict=None, mode="FAST_COMPILE"):
+def unpack_symbolic_matrices_with_params(
+    mod, param_dict, data_dict=None, mode="FAST_COMPILE"
+):
     inputs = list(mod._name_to_variable.values())
     if data_dict is not None:
         inputs += list(mod._name_to_data.values())
@@ -233,7 +237,9 @@ def simulate_from_numpy_model(mod, rng, param_dict, data_dict=None, steps=100):
     """
     Helper function to visualize the components outside of a PyMC model context
     """
-    x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(mod, param_dict, data_dict)
+    x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(
+        mod, param_dict, data_dict
+    )
     k_states = mod.k_states
     k_posdef = mod.k_posdef
 
@@ -287,7 +293,9 @@ def make_stationary_params(data, p, d, q, P, D, Q, S):
     sm_sarimax = sm.tsa.SARIMAX(data, order=(p, d, q), seasonal_order=(P, D, Q, S))
     res = sm_sarimax.fit(disp=False)
 
-    param_dict = dict(ar_params=[], ma_params=[], seasonal_ar_params=[], seasonal_ma_params=[])
+    param_dict = dict(
+        ar_params=[], ma_params=[], seasonal_ar_params=[], seasonal_ma_params=[]
+    )
 
     for name, param in zip(res.param_names, res.params):
         if name.startswith("ar.S"):

--- a/tests/test_blackjax_smc.py
+++ b/tests/test_blackjax_smc.py
@@ -60,7 +60,7 @@ def two_gaussians_model():
 
     with pm.Model() as m:
         X = pm.Uniform("X", lower=-2, upper=2.0, shape=n)
-        llk = pm.Potential("muh", two_gaussians(X))
+        pm.Potential("muh", two_gaussians(X))
 
     return m, mu1
 
@@ -68,7 +68,7 @@ def two_gaussians_model():
 def fast_model():
     with pm.Model() as m:
         x = pm.Normal("x", 0, 1)
-        y = pm.Normal("y", x, 1, observed=0)
+        pm.Normal("y", x, 1, observed=0)
     return m
 
 
@@ -115,7 +115,9 @@ def test_sample_smc_blackjax(kernel, check_for_integration_steps, inner_kernel_p
         assert inference_data.posterior.attrs[attribute] == value
 
     for diagnostic in ["lambda_evolution", "log_likelihood_increments"]:
-        assert inference_data.posterior.attrs[diagnostic].shape == (iterations_to_diagnose,)
+        assert inference_data.posterior.attrs[diagnostic].shape == (
+            iterations_to_diagnose,
+        )
 
     for diagnostic in ["ancestors_evolution", "weights_evolution"]:
         assert inference_data.posterior.attrs[diagnostic].shape == (
@@ -134,33 +136,41 @@ def test_blackjax_particles_from_pymc_population_univariate():
     model = fast_model()
     population = {"x": np.array([2, 3, 4])}
     blackjax_particles = blackjax_particles_from_pymc_population(model, population)
-    jax.tree.map(np.testing.assert_allclose, blackjax_particles, [np.array([[2], [3], [4]])])
+    jax.tree.map(
+        np.testing.assert_allclose, blackjax_particles, [np.array([[2], [3], [4]])]
+    )
 
 
 def test_blackjax_particles_from_pymc_population_multivariate():
     with pm.Model() as model:
         x = pm.Normal("x", 0, 1)
         z = pm.Normal("z", 0, 1)
-        y = pm.Normal("y", x + z, 1, observed=0)
+        pm.Normal("y", x + z, 1, observed=0)
 
-    population = {"x": np.array([0.34614613, 1.09163261, -0.44526825]), "z": np.array([1, 2, 3])}
+    population = {
+        "x": np.array([0.34614613, 1.09163261, -0.44526825]),
+        "z": np.array([1, 2, 3]),
+    }
     blackjax_particles = blackjax_particles_from_pymc_population(model, population)
     jax.tree.map(
         np.testing.assert_allclose,
         blackjax_particles,
-        [np.array([[0.34614613], [1.09163261], [-0.44526825]]), np.array([[1], [2], [3]])],
+        [
+            np.array([[0.34614613], [1.09163261], [-0.44526825]]),
+            np.array([[1], [2], [3]]),
+        ],
     )
 
 
 def simple_multivariable_model():
     """
     A simple model that has a multivariate variable,
-    a has more than one variable (multivariable)
+    and has more than one variable (multivariable)
     """
     with pm.Model() as model:
-        x = pm.Normal("x", 0, 1, shape=2)
+        pm.Normal("x", 0, 1, shape=2)
         z = pm.Normal("z", 0, 1)
-        y = pm.Normal("y", z, 1, observed=0)
+        pm.Normal("y", z, 1, observed=0)
     return model
 
 
@@ -182,7 +192,9 @@ def test_arviz_from_particles():
     with model:
         inference_data = arviz_from_particles(model, particles)
 
-    assert inference_data.posterior.sizes == Frozen({"chain": 1, "draw": 3, "x_dim_0": 2})
+    assert inference_data.posterior.sizes == Frozen(
+        {"chain": 1, "draw": 3, "x_dim_0": 2}
+    )
     assert inference_data.posterior.data_vars.dtypes == Frozen(
         {"x": dtype("float64"), "z": dtype("float64")}
     )

--- a/tests/test_histogram_approximation.py
+++ b/tests/test_histogram_approximation.py
@@ -60,7 +60,9 @@ def test_histogram_init_discrete(use_dask, min_count, ndims):
         dask = pytest.importorskip("dask")
         dask_df = pytest.importorskip("dask.dataframe")
         data = dask_df.from_array(data)
-    histogram = pmx.distributions.histogram_utils.discrete_histogram(data, min_count=min_count)
+    histogram = pmx.distributions.histogram_utils.discrete_histogram(
+        data, min_count=min_count
+    )
     if use_dask:
         (histogram,) = dask.compute(histogram)
     assert isinstance(histogram, dict)
@@ -81,16 +83,16 @@ def test_histogram_init_discrete(use_dask, min_count, ndims):
 def test_histogram_approx_cont(use_dask, ndims):
     data = np.random.randn(*(10000, *(2,) * (ndims - 1)))
     if use_dask:
-        dask = pytest.importorskip("dask")
+        pytest.importorskip("dask")
         dask_df = pytest.importorskip("dask.dataframe")
         data = dask_df.from_array(data)
     with pm.Model():
         m = pm.Normal("m")
         s = pm.HalfNormal("s", size=2 if ndims > 1 else 1)
-        pot = pmx.distributions.histogram_utils.histogram_approximation(
+        pmx.distributions.histogram_utils.histogram_approximation(
             "histogram_potential", pm.Normal.dist(m, s), observed=data, n_quantiles=1000
         )
-        trace = pm.sample(10, tune=0)  # very fast
+        pm.sample(10, tune=0)  # very fast
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
@@ -98,12 +100,12 @@ def test_histogram_approx_cont(use_dask, ndims):
 def test_histogram_approx_discrete(use_dask, ndims):
     data = np.random.randint(0, 100, size=(10000, *(2,) * (ndims - 1)))
     if use_dask:
-        dask = pytest.importorskip("dask")
+        pytest.importorskip("dask")
         dask_df = pytest.importorskip("dask.dataframe")
         data = dask_df.from_array(data)
     with pm.Model():
         s = pm.Exponential("s", 1.0, size=2 if ndims > 1 else 1)
-        pot = pmx.distributions.histogram_utils.histogram_approximation(
+        pmx.distributions.histogram_utils.histogram_approximation(
             "histogram_potential", pm.Poisson.dist(s), observed=data, min_count=10
         )
-        trace = pm.sample(10, tune=0)  # very fast
+        pm.sample(10, tune=0)  # very fast

--- a/tests/test_laplace.py
+++ b/tests/test_laplace.py
@@ -25,7 +25,6 @@ import pymc_experimental as pmx
     + "To suppress this warning set `negate_output=False`:FutureWarning",
 )
 def test_laplace():
-
     # Example originates from Bayesian Data Analyses, 3rd Edition
     # By Andrew Gelman, John Carlin, Hal Stern, David Dunson,
     # Aki Vehtari, and Donald Rubin.
@@ -38,7 +37,7 @@ def test_laplace():
     with pm.Model() as m:
         logsigma = pm.Uniform("logsigma", 1, 100)
         mu = pm.Uniform("mu", -10000, 10000)
-        yobs = pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
+        pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
         vars = [mu, logsigma]
 
     idata = pmx.fit(
@@ -67,7 +66,6 @@ def test_laplace():
     + "To suppress this warning set `negate_output=False`:FutureWarning",
 )
 def test_laplace_only_fit():
-
     # Example originates from Bayesian Data Analyses, 3rd Edition
     # By Andrew Gelman, John Carlin, Hal Stern, David Dunson,
     # Aki Vehtari, and Donald Rubin.
@@ -79,7 +77,7 @@ def test_laplace_only_fit():
     with pm.Model() as m:
         logsigma = pm.Uniform("logsigma", 1, 100)
         mu = pm.Uniform("mu", -10000, 10000)
-        yobs = pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
+        pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
         vars = [mu, logsigma]
 
     idata = pmx.fit(
@@ -105,22 +103,20 @@ def test_laplace_only_fit():
     + "To suppress this warning set `negate_output=False`:FutureWarning",
 )
 def test_laplace_subset_of_rv(recwarn):
-
     # Example originates from Bayesian Data Analyses, 3rd Edition
     # By Andrew Gelman, John Carlin, Hal Stern, David Dunson,
     # Aki Vehtari, and Donald Rubin.
     # See section. 4.1
 
     y = np.array([2642, 3503, 4358], dtype=np.float64)
-    n = y.size
 
     with pm.Model() as m:
         logsigma = pm.Uniform("logsigma", 1, 100)
         mu = pm.Uniform("mu", -10000, 10000)
-        yobs = pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
+        pm.Normal("y", mu=mu, sigma=pm.math.exp(logsigma), observed=y)
         vars = [mu]
 
-    idata = pmx.fit(
+    pmx.fit(
         method="laplace",
         vars=vars,
         draws=None,

--- a/tests/test_linearmodel.py
+++ b/tests/test_linearmodel.py
@@ -75,7 +75,8 @@ def fitted_linear_model_instance(toy_X, toy_y):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Permissions for temp files not granted on windows CI."
+    sys.platform == "win32",
+    reason="Permissions for temp files not granted on windows CI.",
 )
 def test_save_load(fitted_linear_model_instance):
     model = fitted_linear_model_instance
@@ -123,9 +124,15 @@ def test_parameter_fit(toy_X, toy_y, toy_actual_params):
     model = LinearModel(sampler_config=sampler_config)
     model.fit(toy_X, toy_y, random_seed=312)
     fit_params = model.idata.posterior.mean()
-    np.testing.assert_allclose(fit_params["intercept"], toy_actual_params["intercept"], rtol=0.1)
-    np.testing.assert_allclose(fit_params["slope"], toy_actual_params["slope"], rtol=0.1)
-    np.testing.assert_allclose(fit_params["σ_model_fmc"], toy_actual_params["obs_error"], rtol=0.1)
+    np.testing.assert_allclose(
+        fit_params["intercept"], toy_actual_params["intercept"], rtol=0.1
+    )
+    np.testing.assert_allclose(
+        fit_params["slope"], toy_actual_params["slope"], rtol=0.1
+    )
+    np.testing.assert_allclose(
+        fit_params["σ_model_fmc"], toy_actual_params["obs_error"], rtol=0.1
+    )
 
 
 def test_predict(fitted_linear_model_instance):
@@ -154,12 +161,14 @@ def test_predict_posterior(fitted_linear_model_instance, combined):
 @pytest.mark.parametrize("combined", [True, False])
 def test_sample_prior_predictive(samples, combined, toy_X, toy_y):
     model = LinearModel()
-    prior_pred = model.sample_prior_predictive(toy_X, toy_y, samples, combined=combined)[
-        model.output_var
-    ]
+    prior_pred = model.sample_prior_predictive(
+        toy_X, toy_y, samples, combined=combined
+    )[model.output_var]
     draws = model.sampler_config["draws"] if samples is None else samples
     chains = 1
-    expected_shape = (len(toy_X), chains * draws) if combined else (chains, draws, len(toy_X))
+    expected_shape = (
+        (len(toy_X), chains * draws) if combined else (chains, draws, len(toy_X))
+    )
     assert prior_pred.shape == expected_shape
     # TODO: check that extend_idata has the expected effect
 
@@ -179,13 +188,17 @@ def test_id():
     model = LinearModel(model_config=model_config, sampler_config=sampler_config)
 
     expected_id = hashlib.sha256(
-        str(model_config.values()).encode() + model.version.encode() + model._model_type.encode()
+        str(model_config.values()).encode()
+        + model.version.encode()
+        + model._model_type.encode()
     ).hexdigest()[:16]
 
     assert model.id == expected_id
 
 
-@pytest.mark.skipif(not sklearn_available, reason="scikit-learn package is not available.")
+@pytest.mark.skipif(
+    not sklearn_available, reason="scikit-learn package is not available."
+)
 def test_pipeline_integration(toy_X, toy_y):
     model_config = {
         "intercept": {"loc": 0, "scale": 2},
@@ -198,7 +211,9 @@ def test_pipeline_integration(toy_X, toy_y):
             ("input_scaling", StandardScaler()),
             (
                 "linear_model",
-                TransformedTargetRegressor(LinearModel(model_config), transformer=StandardScaler()),
+                TransformedTargetRegressor(
+                    LinearModel(model_config), transformer=StandardScaler()
+                ),
             ),
         ]
     )

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -57,7 +57,9 @@ def get_unfitted_model_instance(X, y):
         "obs_error": 2,
     }
     model = test_ModelBuilder(
-        model_config=model_config, sampler_config=sampler_config, test_parameter="test_paramter"
+        model_config=model_config,
+        sampler_config=sampler_config,
+        test_parameter="test_paramter",
     )
     # Do the things that `model.fit` does except sample to create idata.
     model._generate_and_preprocess_model_data(X, y.values.flatten())
@@ -116,7 +118,7 @@ class test_ModelBuilder(ModelBuilder):
             obs_error = pm.HalfNormal("σ_model_fmc", obs_error)
 
             # observed data
-            output = pm.Normal("output", a + b * x, obs_error, shape=x.shape, observed=y_data)
+            pm.Normal("output", a + b * x, obs_error, shape=x.shape, observed=y_data)
 
     def _save_input_params(self, idata):
         idata.attrs["test_paramter"] = json.dumps(self.test_parameter)
@@ -168,7 +170,8 @@ def test_save_input_params(fitted_model_instance):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Permissions for temp files not granted on windows CI."
+    sys.platform == "win32",
+    reason="Permissions for temp files not granted on windows CI.",
 )
 def test_save_load(fitted_model_instance):
     temp = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
@@ -205,8 +208,10 @@ def test_empty_sampler_config_fit(toy_X, toy_y):
 
 
 def test_fit(fitted_model_instance):
-    prediction_data = pd.DataFrame({"input": np.random.uniform(low=0, high=1, size=100)})
-    pred = fitted_model_instance.predict(prediction_data["input"])
+    prediction_data = pd.DataFrame(
+        {"input": np.random.uniform(low=0, high=1, size=100)}
+    )
+    fitted_model_instance.predict(prediction_data["input"])
     post_pred = fitted_model_instance.sample_posterior_predictive(
         prediction_data["input"], extend_idata=True, combined=True
     )
@@ -226,7 +231,7 @@ def test_predict(fitted_model_instance):
     prediction_data = pd.DataFrame({"input": x_pred})
     pred = fitted_model_instance.predict(prediction_data["input"])
     # Perform elementwise comparison using numpy
-    assert type(pred) == np.ndarray
+    assert type(pred) is np.ndarray
     assert len(pred) > 0
 
 
@@ -261,7 +266,9 @@ def test_sample_xxx_extend_idata_param(fitted_model_instance, group, extend_idat
     else:  # group == "posterior_predictive":
         prediction_method = fitted_model_instance.sample_posterior_predictive
 
-    pred = prediction_method(prediction_data["input"], combined=False, extend_idata=extend_idata)
+    pred = prediction_method(
+        prediction_data["input"], combined=False, extend_idata=extend_idata
+    )
 
     pred_unstacked = pred[output_var].values
     idata_now = fitted_model_instance.idata[group][output_var].values

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -28,12 +28,12 @@ def test_pathfinder():
     y = np.array([28.0, 8.0, -3.0, 7.0, -1.0, 1.0, 18.0, 12.0])
     sigma = np.array([15.0, 10.0, 16.0, 11.0, 9.0, 11.0, 10.0, 18.0])
 
-    with pm.Model() as model:
+    with pm.Model():
         mu = pm.Normal("mu", mu=0.0, sigma=10.0)
         tau = pm.HalfCauchy("tau", 5.0)
 
         theta = pm.Normal("theta", mu=0, sigma=1, shape=J)
-        obs = pm.Normal("obs", mu=mu + tau * theta, sigma=sigma, shape=J, observed=y)
+        pm.Normal("obs", mu=mu + tau * theta, sigma=sigma, shape=J, observed=y)
 
         idata = pmx.fit(method="pathfinder", random_seed=41)
 

--- a/tests/test_prior_from_trace.py
+++ b/tests/test_prior_from_trace.py
@@ -33,7 +33,10 @@ import pymc_experimental as pmx
             dict(name="a", transform=transforms.log, dims=None),
         ),
         (("a", dict(name="b")), dict(name="b", transform=None, dims=None)),
-        (("a", dict(name="b", dims="test")), dict(name="b", transform=None, dims="test")),
+        (
+            ("a", dict(name="b", dims="test")),
+            dict(name="b", transform=None, dims="test"),
+        ),
         (("a", ("test",)), dict(name="a", transform=None, dims=("test",))),
     ],
 )
@@ -149,18 +152,18 @@ def test_mean_chol(flat_info):
 
 def test_mvn_prior_from_flat_info(flat_info, coords, param_cfg):
     with pm.Model(coords=coords) as model:
-        priors = pmx.utils.prior._mvn_prior_from_flat_info("trace_prior_", flat_info)
-        test_prior = pm.sample_prior_predictive(1)
+        pmx.utils.prior._mvn_prior_from_flat_info("trace_prior_", flat_info)
+        pm.sample_prior_predictive(1)
     names = [p["name"] for p in param_cfg.values()]
     assert set(model.named_vars) == {"trace_prior_", *names}
 
 
 def test_prior_from_idata(idata, user_param_cfg, coords, param_cfg):
     with pm.Model(coords=coords) as model:
-        priors = pmx.utils.prior.prior_from_idata(
+        pmx.utils.prior.prior_from_idata(
             idata, var_names=user_param_cfg[0], **user_param_cfg[1]
         )
-        test_prior = pm.sample_prior_predictive(1)
+        pm.sample_prior_predictive(1)
     names = [p["name"] for p in param_cfg.values()]
     assert set(model.named_vars) == {"trace_prior_", *names}
 

--- a/tests/test_splines.py
+++ b/tests/test_splines.py
@@ -44,7 +44,9 @@ def test_spline_construction(dtype, sparse):
 
 @pytest.mark.parametrize("shape", [(100,), (100, 5)])
 @pytest.mark.parametrize("sparse", [True, False])
-@pytest.mark.parametrize("points", [dict(n=1001), dict(eval_points=np.linspace(0, 1, 1001))])
+@pytest.mark.parametrize(
+    "points", [dict(n=1001), dict(eval_points=np.linspace(0, 1, 1001))]
+)
 def test_interpolation_api(shape, sparse, points):
     x = np.random.randn(*shape)
     yt = pmx.utils.spline.bspline_interpolation(x, **points, sparse=sparse)
@@ -55,7 +57,11 @@ def test_interpolation_api(shape, sparse, points):
 @pytest.mark.parametrize(
     "params",
     [
-        (dict(sparse="foo", n=100, degree=1), TypeError, "sparse should be True or False"),
+        (
+            dict(sparse="foo", n=100, degree=1),
+            TypeError,
+            "sparse should be True or False",
+        ),
         (dict(n=100, degree=0.5), TypeError, "degree should be integer"),
         (
             dict(n=100, eval_points=np.linspace(0, 1), degree=1),


### PR DESCRIPTION
This is for #350, because I too wanted to replace black with ruff. There's a lot going on here but it's largely cosmetic. After changing the pre-commit file following the pytensor pre-commit config I:

- ran `pre-commit run --all-files`
- manually changed the remaining errors rather than using the `--unsafe-fixes` option. These were largely import errors (F401) or Local variable `mu` is assigned to but never used (F841, common when people write pymc models in tests).

The dubious ones that I changed which might be bugs were:
- `gp.latent_approx.py` L144 `mu = self.mean_func(X)` never used? Should it be?
- statespace e.g. `def rv_op( # noqa: F811`. I added the skip here but `rv_op` is specified above (e.g. `rv_op = LinearGaussianStateSpaceRV`) then overwritten in a class method. Just checking the desired behaviour