### PR TITLE
Allow forecasting with exogenous variables

### DIFF
--- a/pymc_experimental/statespace/core/statespace.py
+++ b/pymc_experimental/statespace/core/statespace.py
@@ -976,6 +976,7 @@ class PyMCStateSpace:
         self,
         data: pt.TensorLike | None = None,
         data_dims: str | tuple[str] | list[str] | None = None,
+        scenario: dict[str, pd.DataFrame] | pd.DataFrame | None = None,
     ) -> tuple[list[pt.TensorVariable], list[tuple[pt.TensorVariable, pt.TensorVariable]]]:
         """
         Builds a Kalman filter graph using "dummy" pm.Flat distributions for the model variables and sorts the returns
@@ -997,6 +998,9 @@ class PyMCStateSpace:
         grouped_outputs: list of tuple of tensors
             A list of tuples, each containing the mean and covariance of the filtered, predicted, and smoothed states.
         """
+        if scenario is None:
+            scenario = dict()
+
         pm_mod = modelcontext(None)
         self._build_dummy_graph()
         self._insert_random_variables()
@@ -1006,6 +1010,10 @@ class PyMCStateSpace:
                 pm.Data(**self._exog_data_info[name])
 
         self._insert_data_variables()
+
+        for name in self.data_names:
+            if name in scenario.keys():
+                pm.set_data({name: scenario[name]})
 
         x0, P0, c, d, T, Z, R, H, Q = self.unpack_statespace()
 
@@ -1504,14 +1512,277 @@ class PyMCStateSpace:
 
         return matrix_idata
 
-    def forecast(
-        self,
-        idata: InferenceData,
+    @staticmethod
+    def _validate_forecast_args(
+        time_index: pd.Index,
         start: int | pd.Timestamp,
         periods: int | None = None,
         end: int | pd.Timestamp = None,
+        scenario: pd.DataFrame | np.ndarray | None = None,
+        use_scenario_index: bool = False,
+        verbose: bool = True,
+    ):
+        if start not in time_index:
+            raise ValueError("start must be in the data index used to fit the model.")
+        if periods is None and end is None:
+            raise ValueError("Must specify one of either periods or end")
+        if periods is not None and end is not None:
+            raise ValueError("Must specify exactly one of either periods or end")
+        if scenario is None and use_scenario_index:
+            raise ValueError("use_scenario_index=True requires a scenario to be provided.")
+        if scenario is not None and use_scenario_index:
+            if isinstance(scenario, dict):
+                first_df = next(
+                    (df for df in scenario.values() if isinstance(df, pd.DataFrame | pd.Series)),
+                    None,
+                )
+                if first_df is None:
+                    raise ValueError(
+                        "use_scenario_index=True requires a scenario to be a DataFrame or Series."
+                    )
+            elif not isinstance(scenario, pd.DataFrame | pd.Series):
+                raise ValueError(
+                    "use_scenario_index=True requires a scenario to be a DataFrame or Series."
+                )
+        if use_scenario_index and any(arg is not None for arg in [start, end, periods]) and verbose:
+            _log.warning(
+                "start, end, and periods arguments are ignored when use_scenario_index is True. Pass only "
+                "one or the other to avoid this warning, or pass verbose = False."
+            )
+
+    def _get_fit_time_index(self) -> pd.Index:
+        time_index = self._fit_coords.get(TIME_DIM, None) if self._fit_coords is not None else None
+        if time_index is None:
+            raise ValueError(
+                "No time dimension found on coordinates used to fit the model. Has this model been fit?"
+            )
+
+        if isinstance(time_index[0], pd.Timestamp):
+            time_index = pd.DatetimeIndex(time_index)
+        else:
+            time_index = np.array(time_index)
+
+        return time_index
+
+    def _validate_scenario_data(
+        self,
+        scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
+        name: str | None = None,
+        verbose=True,
+    ):
+        if not self._needs_exog_data:
+            return scenario
+
+        var_to_dims = {key: info["dims"][1:] for key, info in self.data_info.items()}
+
+        if any(len(dims) > 1 for dims in var_to_dims.values()):
+            raise NotImplementedError(">2d exogenous data is not yet supported.")
+        coords = {
+            var: self._fit_coords[dim[0]]
+            for var, dim in var_to_dims.items()
+            if dim[0] in self._fit_coords
+        }
+
+        if self._needs_exog_data and scenario is None:
+            exog_str = ",".join(self._exog_names)
+            suffix = "s" if len(exog_str) > 1 else ""
+            raise ValueError(
+                f"This model was fit using exogenous data. Forecasting cannot be performed without "
+                f"providing scenario data for the following variable{suffix}: {exog_str}"
+            )
+
+        if isinstance(scenario, dict):
+            for name, data in scenario.items():
+                if name not in self._exog_names:
+                    raise ValueError(
+                        f"Scenario data provided for variable '{name}', which is not an exogenous variable "
+                        f"used to fit the model."
+                    )
+
+                # Recursively call this function to trigger the non-dictionary branch of the checks on each object
+                # inside the dictionary
+                scenario[name] = self._validate_scenario_data(data, name)
+
+            # The provided dictionary might be a mix of numpy arrays and dataframes if the user is truly horrible.
+            # For checking shapes, the first object will always be good enough. But we also need to make sure all the
+            # indices agree, so we grab the first dataframe (which might not exist, but that's OK)
+            first_scenario = next(iter(scenario.values()))
+            first_df = next((df for df in scenario.values() if isinstance(df, pd.DataFrame)), None)
+
+            if not all(data.shape[0] == first_scenario.shape[0] for data in scenario.values()):
+                raise ValueError(
+                    "Scenario data must have the same number of time steps for all variables."
+                )
+
+            if first_df is not None and not all(
+                df.index.equals(first_df.index)
+                for df in scenario.values()
+                if isinstance(df, pd.DataFrame)
+            ):
+                raise ValueError("Scenario data must have the same index for all variables.")
+
+            return scenario
+
+        elif isinstance(scenario, pd.Series | pd.DataFrame | np.ndarray | list | tuple):
+            # A user might be lazy and pass a simple list when there is only one exogenous variable.
+            if isinstance(scenario, list | tuple) or (
+                isinstance(scenario, np.ndarray) and scenario.ndim == 1
+            ):
+                scenario = np.array(scenario).reshape(-1, 1)
+
+            if name is None:
+                # name should only be None on the first non-recursive call. We only arrive to this branch in that case
+                # if a non-dictionary was passed, which in turn should only happen if only a single exogenous data
+                # needs to be set.
+                if len(self._exog_names) > 1:
+                    raise ValueError(
+                        "Multiple exogenous variables were used to fit the model. Provide a dictionary of "
+                        "scenario data instead."
+                    )
+                name = self._exog_names[0]
+
+            # Omit dataframe from this basic shape check so we can give more detailed information about missing columns
+            # in the next check
+            if not isinstance(scenario, pd.DataFrame | pd.Series) and scenario.shape[1] != len(
+                coords[name]
+            ):
+                raise ValueError(
+                    f"Scenario data for variable '{name}' has the wrong number of columns. Expected "
+                    f"{len(coords[name])}, got {scenario.shape[1]}"
+                )
+
+            if isinstance(scenario, pd.Series):
+                if len(coords[name]) > 1:
+                    raise ValueError(
+                        f"Scenario data for variable '{name}' has the wrong number of columns. Expected "
+                        f"{len(coords[name])}, got 1"
+                    )
+
+            if isinstance(scenario, pd.DataFrame):
+                expected_cols = coords[name]
+                cols = scenario.columns
+                missing_columns = sorted(list(set(expected_cols) - set(cols)))
+                if len(missing_columns) > 0:
+                    suffix = "s" if len(missing_columns) > 1 else ""
+                    raise ValueError(
+                        f"Scenario data for variable '{name}' is missing the following column{suffix}: "
+                        f"{', '.join(missing_columns)}"
+                    )
+
+                extra_columns = sorted(list(set(cols) - set(expected_cols)))
+                if len(extra_columns) > 0:
+                    suffix = "s" if len(extra_columns) > 1 else ""
+                    verb = "is" if len(extra_columns) == 1 else "are"
+                    raise ValueError(
+                        f"Scenario data for variable '{name}' contains the following extra column{suffix} "
+                        f"that {verb} not used by the model: "
+                        f"{', '.join(extra_columns)}"
+                    )
+
+                if not (a == b for a, b in zip(expected_cols, cols)) and verbose:
+                    _log.warning(
+                        f"Scenario data for {name} has a different column order than the data used to fit the "
+                        f"model. Columns will be automatically re-ordered. Ensure consistent ordering to avoid "
+                        f"silent errors."
+                    )
+                    scenario = scenario[expected_cols]
+
+            return scenario
+
+    @staticmethod
+    def _build_forecast_index(
+        time_index: pd.RangeIndex | pd.DatetimeIndex,
+        start: int | pd.Timestamp | None = None,
+        end: int | pd.Timestamp = None,
+        periods: int | None = None,
+        use_scenario_index: bool = False,
+        scenario: pd.DataFrame | np.ndarray | None = None,
+    ) -> pd.Index:
+        if use_scenario_index:
+            if isinstance(scenario, pd.DataFrame):
+                return scenario.index
+            if isinstance(scenario, dict):
+                first_df = next(
+                    (df for df in scenario.values() if isinstance(df, pd.DataFrame)), None
+                )
+                return first_df.index
+
+        # Otherwise, build an index. It will be a DateTime index if we have all the necessary information, otherwise
+        # use a range index.
+        is_datetime = isinstance(time_index, pd.DatetimeIndex)
+        forecast_index = None
+
+        if is_datetime:
+            freq = time_index.inferred_freq
+
+            if end is not None:
+                forecast_index = pd.date_range(start, end=end, freq=freq)
+            if periods is not None:
+                forecast_index = pd.date_range(start, periods=periods, freq=freq)
+
+        else:
+            if end is not None:
+                forecast_index = pd.RangeIndex(start, end, step=1, dtype="int")
+            if periods is not None:
+                forecast_index = pd.RangeIndex(start, start + periods, step=1, dtype="int")
+
+        return forecast_index
+
+    def _finalize_scenario_initialization(
+        self,
+        scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
+        forecast_index: pd.RangeIndex | pd.DatetimeIndex,
+        name=None,
+    ):
+        try:
+            var_to_dims = {key: info["dims"][1:] for key, info in self.data_info.items()}
+        except NotImplementedError:
+            return scenario
+
+        if any(len(dims) > 1 for dims in var_to_dims.values()):
+            raise NotImplementedError(">2d exogenous data is not yet supported.")
+        coords = {
+            var: self._fit_coords[dim[0]]
+            for var, dim in var_to_dims.items()
+            if dim[0] in self._fit_coords
+        }
+
+        if scenario is None:
+            return scenario
+
+        if isinstance(scenario, dict):
+            for name, data in scenario.items():
+                scenario[name] = self._finalize_scenario_initialization(data, forecast_index, name)
+            return scenario
+
+        # This was already checked as valid
+        name = self._exog_names[0] if name is None else name
+
+        # Small tidying up in the case we just have a single scenario that's already a dataframe.
+        if isinstance(scenario, pd.DataFrame | pd.Series):
+            if isinstance(scenario, pd.Series):
+                scenario = scenario.to_frame(name=coords[name][0])
+            if not scenario.index.equals(forecast_index):
+                scenario.index = forecast_index
+
+        # lists and tuples were handled during validation, along with shape check, so just cast arrays to dataframes
+        # with the correct index and columns
+        if isinstance(scenario, np.ndarray):
+            scenario = pd.DataFrame(scenario, index=forecast_index, columns=coords[name])
+
+        return scenario
+
+    def forecast(
+        self,
+        idata: InferenceData,
+        start: int | pd.Timestamp | None = None,
+        periods: int | None = None,
+        end: int | pd.Timestamp = None,
+        scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None = None,
+        use_scenario_index: bool = False,
         filter_output="smoothed",
         random_seed: RandomState | None = None,
+        verbose: bool = True,
         **kwargs,
     ) -> InferenceData:
         """
@@ -1526,21 +1797,36 @@ class PyMCStateSpace:
         idata : InferenceData
             An Arviz InferenceData object containing the posterior distribution over model parameters.
 
-        start : Union[int, pd.Timestamp]
+        start : int or pd.Timestamp, optional
             The starting date index or time step from which to generate the forecasts. If the data provided to
             `PyMCStateSpace.build_statespace_graph` had a datetime index, `start` should be a datetime.
             If using integer time series, `start` should be an integer indicating the starting time step. In either
             case, `start` should be in the data index used to build the statespace graph.
 
-        periods : Optional[int], default=None
+            If start is None, the last value on the data's index will be used.
+
+        periods : int, optional
             The number of time steps to forecast into the future. If `periods` is specified, the `end`
             parameter will be ignored. If `None`, then the `end` parameter must be provided.
 
-        end : Union[int, pd.Timestamp], default=None
+        end : int or pd.Timestamp, optional
             The ending date index or time step up to which to generate the forecasts. If the data provided to
             `PyMCStateSpace.build_statespace_graph` had a datetime index, `start` should be a datetime.
             If using integer time series, `end` should be an integer indicating the ending time step.
             If `end` is provided, the `periods` parameter will be ignored.
+
+        scenario: pd.Dataframe or np.ndarray, optional
+            Exogenous variables to use for scenario-based forecasting. Must be a 2d array-like, with second dimension
+            equal to the number of exogenous variables. If start, end, or periods are specified, the first dimension
+            must conform with these settings. Otherwise, the index of the scenario data will be used to set the
+            number of forecast steps. If the index of the forecast scenairo is a pandas DateTimeIndex, its frequency
+            must match the frequency of the data used to fit the model. Otherwise, dates will be based on the number
+            of forecast steps and the data.
+
+        use_scenario_index: bool, default False
+            If True, the index of the scenario data will be used to determine the forecast period. In this case,
+            the start, end, and periods arguments will be ignored. If True, the scenario data must be a DataFrame,
+            otherwise an error will be raised.
 
         filter_output : str, default="smoothed"
             The type of Kalman Filter output used to initialize the forecasts. The 0th timestep of the forecast will
@@ -1549,6 +1835,9 @@ class PyMCStateSpace:
 
         random_seed : int, RandomState or Generator, optional
             Seed for the random number generator.
+
+        verbose: bool, default=True
+            Whether to print diagnostic information about forecasting.
 
         kwargs:
             Additional keyword arguments are passed to pymc.sample_posterior_predictive
@@ -1566,51 +1855,49 @@ class PyMCStateSpace:
                   the latent state trajectories: `y[t] = Z @ x[t] + nu[t]`, where `nu ~ N(0, H)`.
 
         """
-        _validate_filter_arg(filter_output)
-        if periods is None and end is None:
-            raise ValueError("Must specify one of either periods or end")
-        if periods is not None and end is not None:
-            raise ValueError("Must specify exactly one of either periods or end")
-        if self._needs_exog_data:
-            raise ValueError(
-                "Scenario-based forcasting with exogenous variables not currently supported"
-            )
-
-        temp_coords = self._fit_coords.copy()
-
         filter_time_dim = TIME_DIM
+
+        _validate_filter_arg(filter_output)
+        time_index = self._get_fit_time_index()
+
+        if start is None and verbose:
+            _log.warning(
+                "No start date provided. Using the last date in the data index. To silence this warning, "
+                "explicitly pass a start date or set verbose = False"
+            )
+            start = time_index[-1]
+
+        scenario = self._validate_scenario_data(scenario, verbose=verbose)
+
+        self._validate_forecast_args(
+            time_index=time_index,
+            start=start,
+            end=end,
+            periods=periods,
+            scenario=scenario,
+            use_scenario_index=use_scenario_index,
+            verbose=verbose,
+        )
+
+        forecast_index = self._build_forecast_index(
+            time_index=time_index,
+            start=start,
+            end=end,
+            periods=periods,
+            scenario=scenario,
+            use_scenario_index=use_scenario_index,
+        )
+
+        scenario = self._finalize_scenario_initialization(scenario, forecast_index)
+        temp_coords = self._fit_coords.copy()
 
         dims = None
         if all([dim in temp_coords for dim in [filter_time_dim, ALL_STATE_DIM, OBS_STATE_DIM]]):
             dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
-        time_index = temp_coords[filter_time_dim]
-
-        if start not in time_index:
-            raise ValueError("Start date is not in the provided data")
-
-        is_datetime = isinstance(time_index[0], pd.Timestamp)
-
-        forecast_index = None
-
-        if is_datetime:
-            time_index = pd.DatetimeIndex(time_index)
-            freq = time_index.inferred_freq
-
-            if end is not None:
-                forecast_index = pd.date_range(start, end=end, freq=freq)
-            if periods is not None:
-                forecast_index = pd.date_range(start, periods=periods, freq=freq)
-            t0 = forecast_index[0]
-
-        else:
-            if end is not None:
-                forecast_index = np.arange(start, end, dtype="int")
-            if periods is not None:
-                forecast_index = np.arange(start, start + periods, dtype="int")
-            t0 = forecast_index[0]
-
+        t0 = forecast_index[0]
         t0_idx = np.flatnonzero(time_index == t0)[0]
+
         temp_coords["data_time"] = time_index
         temp_coords[TIME_DIM] = forecast_index
 
@@ -1620,22 +1907,11 @@ class PyMCStateSpace:
             cov_dims = ["data_time", ALL_STATE_DIM, ALL_STATE_AUX_DIM]
 
         with pm.Model(coords=temp_coords) as forecast_model:
-            (
-                [
-                    x0,
-                    P0,
-                    c,
-                    d,
-                    T,
-                    Z,
-                    R,
-                    H,
-                    Q,
-                ],
-                grouped_outputs,
-            ) = self._kalman_filter_outputs_from_dummy_graph(data_dims=["data_time", OBS_STATE_DIM])
-            group_idx = FILTER_OUTPUT_TYPES.index(filter_output)
+            (_, _, *matrices), grouped_outputs = self._kalman_filter_outputs_from_dummy_graph(
+                data_dims=["data_time", OBS_STATE_DIM]
+            )
 
+            group_idx = FILTER_OUTPUT_TYPES.index(filter_output)
             mu, cov = grouped_outputs[group_idx]
 
             x0 = pm.Deterministic(
@@ -1645,17 +1921,27 @@ class PyMCStateSpace:
                 "P0_slice", cov[t0_idx], dims=cov_dims[1:] if cov_dims is not None else None
             )
 
+            if scenario is not None:
+                sub_dict = {
+                    forecast_model[data_name]: pt.as_tensor_variable(
+                        scenario.get(data_name), name="data_var"
+                    )
+                    for data_name in self.data_names
+                }
+
+                subbed_matrices = graph_replace(matrices, replace=sub_dict, strict=True)
+                [
+                    setattr(matrix, "name", name)
+                    for name, matrix in zip(MATRIX_NAMES[2:], subbed_matrices)
+                ]
+            else:
+                subbed_matrices = matrices
+
             _ = LinearGaussianStateSpace(
                 "forecast",
                 x0,
                 P0,
-                c,
-                d,
-                T,
-                Z,
-                R,
-                H,
-                Q,
+                *subbed_matrices,
                 steps=len(forecast_index[:-1]),
                 dims=dims,
                 mode=self._fit_mode,

--- a/pymc_experimental/statespace/filters/kalman_filter.py
+++ b/pymc_experimental/statespace/filters/kalman_filter.py
@@ -642,15 +642,15 @@ class StandardFilter(BaseFilter):
         PZT = P.dot(Z.T)
         F = Z.dot(PZT) + stabilize(H, self.cov_jitter)
 
-        F_inv = pt.linalg.solve(F, self.eye_endog, assume_a="pos", check_finite=False)
-
-        K = PZT.dot(F_inv)
+        K = pt.linalg.solve(F.T, PZT.T, assume_a="pos", check_finite=False).T
         I_KZ = self.eye_states - K.dot(Z)
 
         a_filtered = a + K.dot(v)
         P_filtered = quad_form_sym(I_KZ, P) + quad_form_sym(K, H)
 
-        inner_term = matrix_dot(v.T, F_inv, v)
+        F_inv_v = pt.linalg.solve(F, v, assume_a="pos", check_finite=False)
+        inner_term = v.T @ F_inv_v
+
         F_logdet = pt.log(pt.linalg.det(F))
 
         ll = pt.switch(

--- a/pymc_experimental/statespace/models/VARMAX.py
+++ b/pymc_experimental/statespace/models/VARMAX.py
@@ -220,11 +220,11 @@ class BayesianVARMAX(PyMCStateSpace):
                 "constraints": "Positive Semi-definite",
             },
             "ar_params": {
-                "shape": (self.k_states, self.p, self.k_states),
+                "shape": (self.k_endog, self.p, self.k_endog),
                 "constraints": "None",
             },
             "ma_params": {
-                "shape": (self.k_states, self.q, self.k_states),
+                "shape": (self.k_endog, self.q, self.k_endog),
                 "constraints": "None",
             },
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ filterwarnings =[
 
   # Warning coming from blackjax
   'ignore:jax\.tree_map is deprecated:DeprecationWarning',
-
-  # Warning from shutil, used by pytensor
-  'ignore:Use shutil\.which instead of find_executable:DeprecationWarning'
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ filterwarnings =[
 
   # Warning coming from blackjax
   'ignore:jax\.tree_map is deprecated:DeprecationWarning',
+
+  # Warning from shutil, used by pytensor
+  'ignore:Use shutil\.which instead of find_executable:DeprecationWarning'
 ]
 
 [tool.coverage.report]

--- a/tests/statespace/test_statespace.py
+++ b/tests/statespace/test_statespace.py
@@ -380,7 +380,9 @@ def test_bad_forecast_arguments(use_datetime_index, caplog):
     time_idx = _make_time_idx(ss_mod, use_datetime_index)
 
     # Start value not in time index
-    with pytest.raises(ValueError, match="start must be in the data index used to fit the model"):
+    with pytest.raises(
+        ValueError, match="Integer start must be in the data index used to fit the model"
+    ):
         start = time_idx.shift(10)[-1] if use_datetime_index else time_idx[-1] + 11
         ss_mod._validate_forecast_args(time_index=time_idx, start=start, periods=10)
 

--- a/tests/statespace/test_statespace.py
+++ b/tests/statespace/test_statespace.py
@@ -380,9 +380,12 @@ def test_bad_forecast_arguments(use_datetime_index, caplog):
     time_idx = _make_time_idx(ss_mod, use_datetime_index)
 
     # Start value not in time index
-    with pytest.raises(
-        ValueError, match="Integer start must be in the data index used to fit the model"
-    ):
+    match = (
+        "Datetime start must be in the data index used to fit the model"
+        if use_datetime_index
+        else "Integer start must be within the range of the data index used to fit the model."
+    )
+    with pytest.raises(ValueError, match=match):
         start = time_idx.shift(10)[-1] if use_datetime_index else time_idx[-1] + 11
         ss_mod._validate_forecast_args(time_index=time_idx, start=start, periods=10)
 


### PR DESCRIPTION
Enable scenario-based forcasting in VARMAX, SARIMAX, and structural models with regressions.

Couple to-dos before its ready for review:

- [x] Carefully check the timing on the forecasting. Things seem to be shifted forward by 1 or 2 periods.
- [x] Recycle the exogenous forecasting code to allow in-sample counterfactual scenarios using `sample_conditional_posterior` or `sample_conditional_prior`. 
- [ ] Update relevant example notebooks to show how to use the scenario tools

Otherwise things seem to be working