### PR TITLE
Remove test.pypi step on releases

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -45,35 +45,10 @@ jobs:
         with:
           name: artifact
           path: dist/*
-  test:
-    name: upload to test PyPI
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip_existing: true
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Test pip install from test.pypi
-        run: |
-          python -m venv venv-test-pypi
-          venv-test-pypi/bin/python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pymc-experimental
-          echo "Checking import and version number"
-          venv-test-pypi/bin/python -c "import pymc_experimental; assert pymc_experimental.__version__ == '${{ github.ref_name }}'[1:]"
 
   publish:
     name: upload release to PyPI
-    needs: [build, test]
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
Since we don't have access to the project on test.pypi, that step would fail and block any attempt of making new releases.