### PR TITLE
Remove dead code from `kalman_filter.py`

### DIFF
--- a/pymc_experimental/statespace/core/statespace.py
+++ b/pymc_experimental/statespace/core/statespace.py
@@ -19,7 +19,6 @@ from pytensor.compile import get_mode
 from pymc_experimental.statespace.core.representation import PytensorRepresentation
 from pymc_experimental.statespace.filters import (
     KalmanSmoother,
-    SingleTimeseriesFilter,
     SquareRootFilter,
     StandardFilter,
     UnivariateFilter,
@@ -52,7 +51,6 @@ floatX = pytensor.config.floatX
 FILTER_FACTORY = {
     "standard": StandardFilter,
     "univariate": UnivariateFilter,
-    "single": SingleTimeseriesFilter,
     "cholesky": SquareRootFilter,
 }
 

--- a/pymc_experimental/statespace/core/statespace.py
+++ b/pymc_experimental/statespace/core/statespace.py
@@ -18,9 +18,9 @@ from pytensor.compile import get_mode
 
 from pymc_experimental.statespace.core.representation import PytensorRepresentation
 from pymc_experimental.statespace.filters import (
-    CholeskyFilter,
     KalmanSmoother,
     SingleTimeseriesFilter,
+    SquareRootFilter,
     StandardFilter,
     SteadyStateFilter,
     UnivariateFilter,
@@ -55,7 +55,7 @@ FILTER_FACTORY = {
     "univariate": UnivariateFilter,
     "steady_state": SteadyStateFilter,
     "single": SingleTimeseriesFilter,
-    "cholesky": CholeskyFilter,
+    "cholesky": SquareRootFilter,
 }
 
 

--- a/pymc_experimental/statespace/core/statespace.py
+++ b/pymc_experimental/statespace/core/statespace.py
@@ -22,7 +22,6 @@ from pymc_experimental.statespace.filters import (
     SingleTimeseriesFilter,
     SquareRootFilter,
     StandardFilter,
-    SteadyStateFilter,
     UnivariateFilter,
 )
 from pymc_experimental.statespace.filters.distributions import (
@@ -53,7 +52,6 @@ floatX = pytensor.config.floatX
 FILTER_FACTORY = {
     "standard": StandardFilter,
     "univariate": UnivariateFilter,
-    "steady_state": SteadyStateFilter,
     "single": SingleTimeseriesFilter,
     "cholesky": SquareRootFilter,
 }

--- a/pymc_experimental/statespace/filters/__init__.py
+++ b/pymc_experimental/statespace/filters/__init__.py
@@ -3,7 +3,6 @@ from pymc_experimental.statespace.filters.kalman_filter import (
     SingleTimeseriesFilter,
     SquareRootFilter,
     StandardFilter,
-    SteadyStateFilter,
     UnivariateFilter,
 )
 from pymc_experimental.statespace.filters.kalman_smoother import KalmanSmoother
@@ -11,7 +10,6 @@ from pymc_experimental.statespace.filters.kalman_smoother import KalmanSmoother
 __all__ = [
     "StandardFilter",
     "UnivariateFilter",
-    "SteadyStateFilter",
     "KalmanSmoother",
     "SingleTimeseriesFilter",
     "SquareRootFilter",

--- a/pymc_experimental/statespace/filters/__init__.py
+++ b/pymc_experimental/statespace/filters/__init__.py
@@ -1,6 +1,5 @@
 from pymc_experimental.statespace.filters.distributions import LinearGaussianStateSpace
 from pymc_experimental.statespace.filters.kalman_filter import (
-    SingleTimeseriesFilter,
     SquareRootFilter,
     StandardFilter,
     UnivariateFilter,
@@ -11,7 +10,6 @@ __all__ = [
     "StandardFilter",
     "UnivariateFilter",
     "KalmanSmoother",
-    "SingleTimeseriesFilter",
     "SquareRootFilter",
     "LinearGaussianStateSpace",
 ]

--- a/pymc_experimental/statespace/filters/__init__.py
+++ b/pymc_experimental/statespace/filters/__init__.py
@@ -1,7 +1,7 @@
 from pymc_experimental.statespace.filters.distributions import LinearGaussianStateSpace
 from pymc_experimental.statespace.filters.kalman_filter import (
-    CholeskyFilter,
     SingleTimeseriesFilter,
+    SquareRootFilter,
     StandardFilter,
     SteadyStateFilter,
     UnivariateFilter,
@@ -14,6 +14,6 @@ __all__ = [
     "SteadyStateFilter",
     "KalmanSmoother",
     "SingleTimeseriesFilter",
-    "CholeskyFilter",
+    "SquareRootFilter",
     "LinearGaussianStateSpace",
 ]

--- a/pymc_experimental/statespace/filters/kalman_filter.py
+++ b/pymc_experimental/statespace/filters/kalman_filter.py
@@ -730,14 +730,14 @@ class SquareRootFilter(BaseFilter):
             loglike_obs,
         ) = results
 
-        def square_sequnece(L):
+        def square_sequnece(L, k):
             X = pt.einsum("...ij,...kj->...ik", L, L.copy())
-            X = pt.specify_shape(X, (n, self.n_states, self.n_states))
+            X = pt.specify_shape(X, (n, k, k))
             return X
 
-        filtered_covariances = square_sequnece(filtered_covariances_cholesky)
-        predicted_covariances = square_sequnece(predicted_covariances_cholesky)
-        observed_covariances = square_sequnece(observed_covariances_cholesky)
+        filtered_covariances = square_sequnece(filtered_covariances_cholesky, k=self.n_states)
+        predicted_covariances = square_sequnece(predicted_covariances_cholesky, k=self.n_states)
+        observed_covariances = square_sequnece(observed_covariances_cholesky, k=self.n_endog)
 
         return [
             filtered_states,

--- a/tests/statespace/test_distributions.py
+++ b/tests/statespace/test_distributions.py
@@ -38,8 +38,6 @@ filter_names = [
     "standard",
     "cholesky",
     "univariate",
-    "single",
-    "steady_state",
 ]
 
 

--- a/tests/statespace/test_statespace.py
+++ b/tests/statespace/test_statespace.py
@@ -234,12 +234,6 @@ def test_invalid_filter_name_raises():
         mod = make_statespace_mod(k_endog=1, k_states=5, k_posdef=1, filter_type="invalid_filter")
 
 
-def test_singleseriesfilter_raises_if_k_endog_gt_one():
-    msg = 'Cannot use filter_type = "single" with multiple observed time series'
-    with pytest.raises(ValueError, match=msg):
-        mod = make_statespace_mod(k_endog=10, k_states=5, k_posdef=1, filter_type="single")
-
-
 def test_unpack_before_insert_raises(rng):
     p, m, r, n = 2, 5, 1, 10
     data, *inputs = make_test_inputs(p, m, r, n, rng, missing_data=0)

--- a/tests/statespace/utilities/test_helpers.py
+++ b/tests/statespace/utilities/test_helpers.py
@@ -34,18 +34,18 @@ def load_nile_test_data():
     return nile
 
 
-def initialize_filter(kfilter, mode=None):
+def initialize_filter(kfilter, mode=None, p=None, m=None, r=None, n=None):
     ksmoother = KalmanSmoother()
-    data = pt.matrix(name="data", dtype=floatX)
-    a0 = pt.vector(name="a0", dtype=floatX)
-    P0 = pt.matrix(name="P0", dtype=floatX)
-    c = pt.vector(name="c", dtype=floatX)
-    d = pt.vector(name="d", dtype=floatX)
-    Q = pt.matrix(name="Q", dtype=floatX)
-    H = pt.matrix(name="H", dtype=floatX)
-    T = pt.matrix(name="T", dtype=floatX)
-    R = pt.matrix(name="R", dtype=floatX)
-    Z = pt.matrix(name="Z", dtype=floatX)
+    data = pt.tensor(name="data", dtype=floatX, shape=(n, p))
+    a0 = pt.tensor(name="x0", dtype=floatX, shape=(m,))
+    P0 = pt.tensor(name="P0", dtype=floatX, shape=(m, m))
+    c = pt.tensor(name="c", dtype=floatX, shape=(m,))
+    d = pt.tensor(name="d", dtype=floatX, shape=(p,))
+    Q = pt.tensor(name="Q", dtype=floatX, shape=(r, r))
+    H = pt.tensor(name="H", dtype=floatX, shape=(p, p))
+    T = pt.tensor(name="T", dtype=floatX, shape=(m, m))
+    R = pt.tensor(name="R", dtype=floatX, shape=(m, r))
+    Z = pt.tensor(name="Z", dtype=floatX, shape=(p, m))
 
     inputs = [data, a0, P0, c, d, T, Z, R, H, Q]
 


### PR DESCRIPTION
My original vision for `kalman_filter.py` was quite bad. Following `statsmodels`, I made a bunch of classes that instantiate various types of kalman filters, with minor differences between them. The idea was to let the user pick what would work best in his given situation.

Looking at it now, this should all be accomplished via rewrites. Some of it already is. For example, the only difference between the `StandardFilter` and the `SingleTimeSeriesFilter` was that I replaced a matrix inverse with a division. This is done automatically in rewrites, so there's no need for it.

I removed the `SteadyStateFilter` because that never made sense. Instead, all of the filters should be checking for convergence to the steady state -- that will be an upcoming PR.

`CholeskyFilter` has been renamed to `SquareRootFilter`, and it actually *is* a square root filter. I let the user pick it for now, but my plan is to rewrite to this when we see that the user has provided a lower triangular `P0`. I haven't benchmarked it, but it should be faster in that case (since solves are replaced with solve_triangular everywhere)